### PR TITLE
Mav 3764/add account

### DIFF
--- a/.codex/skills/api-sync/SKILL.md
+++ b/.codex/skills/api-sync/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: api-sync
+description: Use this when integrating or updating wallet API endpoints, schemas, parsers, reducers, and UI-facing mapped data for the Mavryk Wallet extension.
+---
+
+# Purpose
+
+Use this skill when:
+
+- adding a new backend endpoint
+- migrating old frontend logic to the new wallet API
+- updating response schemas or types
+- mapping API responses into existing frontend data structures
+- keeping UI/reducers stable while changing fetch/parsing logic
+
+# Project context
+
+This project is a React + TypeScript wallet extension with blockchain integrations.
+
+Important backend direction:
+
+- frontend is migrating to the new wallet backend
+- responses should be converted into UI-ready structures
+- avoid unnecessary UI rewrites when backend payloads change
+- prefer updating fetch/parsing/schema layers instead of changing many UI components
+
+Common endpoint patterns already used:
+
+- `/wallets/{wallet_address}/portfolio`
+- `/wallets/{wallet_address}/tokens`
+- `/wallets/{wallet_address}/assets`
+- `/wallets/{wallet_address}/history`
+
+# Rules
+
+- Be concise and factual.
+- Follow existing project structure and naming.
+- Reuse existing helpers before creating new ones.
+- Prefer minimal safe changes over broad refactors.
+- Do not break reducer/UI output shape unless explicitly required.
+- Keep TypeScript strict and explicit.
+- Handle missing/invalid API fields safely.
+- Do not silently swallow parsing or mapping errors.
+- Prefer colocating endpoint-specific parsing helpers near existing API helpers.
+- If zod or schema validation is already used nearby, extend that pattern instead of inventing a new one.
+
+# Workflow
+
+When working on an API task:
+
+1. Find the existing API layer for the domain.
+
+   - Search for current client usage, endpoint helpers, schemas, mappers, reducers, and selectors.
+   - Identify where the UI-facing shape is defined.
+
+2. Inspect the current expected frontend shape.
+
+   - Check reducers, selectors, hooks, and components that consume the data.
+   - Preserve that shape unless the task explicitly asks to change it.
+
+3. Add or update response typing.
+
+   - Create or update TypeScript types for raw API response data.
+   - Add schema validation if the nearby code already uses it.
+
+4. Add mapping/parsing logic.
+
+   - Transform raw API response into the existing frontend structure.
+   - Convert numeric/string values carefully.
+   - Respect token decimals and backend-provided fee/value fields.
+
+5. Update fetch logic only where needed.
+
+   - Keep the change local.
+   - Do not rewrite unrelated flows.
+
+6. Verify impact.
+
+   - Check reducers/selectors/components using the mapped data.
+   - Remove obsolete fields only if they are truly unused or explicitly deprecated.
+
+7. Update docs/comments only if the change introduces new behavior or important assumptions.
+
+# Output expectations
+
+For implementation tasks:
+
+- make the code change
+- explain briefly what was changed
+- call out any assumptions or risky areas
+
+For analysis tasks:
+
+- identify exact files to change
+- explain old shape vs new shape
+- propose smallest safe implementation plan
+
+# Mavryk-specific guidance
+
+- Wallet UI shape stability matters.
+- New backend should be the source of truth for balances, prices, fees, and operation metadata when available.
+- Prefer backend `networkFees` over old custom fee calculations where the feature has been migrated.
+- Do not duplicate mapping logic across tokens, portfolio, RWA, and history if an existing helper pattern already exists.
+- If a reducer currently expects a legacy shape, adapt the parser/helper rather than forcing broad UI changes.
+- Preserve pagination/filter contract behavior where relevant.
+
+# Things to double-check
+
+- decimals handling
+- currency value correctness
+- grouping logic
+- null/empty states
+- backward compatibility with existing selectors/hooks
+- endpoint URL construction
+- atlasnet vs mainnet compatibility if API base depends on selected network

--- a/.codex/skills/auth-flow/SKILL.md
+++ b/.codex/skills/auth-flow/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: auth-flow
+description: Use this when working on wallet authentication, JWT storage, refresh behavior, network-based auth, unlock/lock flows, and protected API access in the Mavryk Wallet extension.
+---
+
+# Purpose
+
+Use this skill when:
+
+- fixing JWT refresh issues
+- implementing auth on wallet import/unlock/network switch
+- storing tokens by wallet/network
+- updating axios interceptors
+- handling logout/lock/auth failure flows
+- preventing repeated unnecessary auth or refresh calls
+
+# Project context
+
+This wallet uses challenge/verify/refresh auth flow.
+
+Known auth contract:
+
+- `POST /auth/challenge`
+- `POST /auth/verify`
+- `POST /auth/refresh`
+- `POST /auth/logout`
+
+Known desired behavior:
+
+- auth should happen when main wallet is first created/imported
+- auth should happen when needed for the selected wallet/network
+- do not refresh on every page reload
+- do not spam refresh calls
+- refresh should happen on unlock, near expiry, or after relevant protected request failure if that flow exists
+- tokens should be stored per main wallet and selected network
+- when network changes, auth should correspond to that network
+- when auth cannot be recovered safely, lock/logout flow should be used
+
+# Rules
+
+- Do not change auth behavior broadly unless required by the task.
+- Prefer deterministic flows over hidden background magic.
+- Avoid repeated refresh on app startup if token is still valid.
+- Keep storage keys explicit and stable.
+- Skip refresh logic for auth endpoints themselves.
+- Prevent interceptor loops and duplicate refresh races.
+- Handle missing tokens, expired tokens, and wrong-network tokens clearly.
+- Reuse existing storage helpers and auth actions if present.
+- If lock/logout behavior already exists in `actions.ts`, use it instead of duplicating logout logic elsewhere.
+
+# Workflow
+
+1. Identify current auth entry points.
+
+   - wallet import/create
+   - account import from seed phrase if it creates/imports main wallet
+   - unlock
+   - network switch
+   - protected API request path
+   - lock/logout
+
+2. Identify current token storage shape.
+
+   - verify whether tokens are keyed by main wallet + network
+   - update storage helpers if needed
+   - keep migration/backward compatibility in mind
+
+3. Inspect axios/client interceptor flow.
+
+   - ensure auth endpoints are excluded from refresh retry logic
+   - prevent infinite loops
+   - prevent refresh on every reload
+
+4. Implement token validity logic.
+
+   - check whether access token exists
+   - check whether it is expired or expiring soon
+   - refresh only when needed
+   - if refresh fails or token is no longer safe to use, call the existing lock/logout path
+
+5. Align network-based auth behavior.
+
+   - selected network must choose the correct API/auth context
+   - switching network must re-evaluate auth state for that wallet/network pair
+
+6. Validate downstream behavior.
+   - contacts or other protected data should fetch only after valid auth is available
+   - app should not fetch protected resources too early
+
+# Output expectations
+
+For implementation tasks:
+
+- make the smallest safe fix
+- describe trigger points changed
+- explain how repeated refresh was prevented
+
+For analysis tasks:
+
+- show the current broken trigger pattern
+- propose exact fix locations
+- call out race conditions or loops
+
+# Mavryk-specific guidance
+
+- Token storage should be per main wallet address and selected network / chain context.
+- Refresh should not happen just because the page reloaded.
+- Unlock is a valid place to verify/refresh auth state.
+- Network switch is a valid place to verify auth for that specific API/network.
+- If auth is required before contacts or account data fetch, wait until auth is ready.
+- Prefer centralizing auth checks instead of scattering them through UI code.
+- If there is already logic in `src/lib/temple/back/actions.ts`, extend that path instead of creating a parallel auth flow.
+
+# Things to double-check
+
+- repeated refresh on reload
+- refresh loop in interceptors
+- auth endpoints excluded from retry logic
+- stale token after network switch
+- stale token after wallet switch
+- storage key correctness
+- lock/logout on unrecoverable auth state
+- concurrent request behavior during refresh

--- a/.codex/skills/operations-parser/SKILL.md
+++ b/.codex/skills/operations-parser/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: operations-parser
+description: Use this when updating operation history parsing, pending operation simulation, fee mapping, operation grouping, pagination/filter behavior, and UI-facing operation models in the Mavryk Wallet extension.
+---
+
+# Purpose
+
+Use this skill when:
+
+- updating `/history` parsing
+- migrating operation models to the new API structure
+- fixing pending operation fake objects
+- mapping fees, amount, timestamps, and statuses
+- handling operation filters and pagination
+- grouping operations by hash
+- updating display data for delegation/staking/unstaking/interactions/etc.
+
+# Project context
+
+Operation history in the wallet is evolving from old custom frontend logic to new backend-provided operation data.
+
+Known backend direction:
+
+- backend returns grouped or groupable operation data
+- `networkFees` should be used where available
+- operation types may include:
+  - sent
+  - received
+  - delegation
+  - staking
+  - origination
+  - reveal
+  - interaction
+  - swap or other backend-defined types if added
+- some pending operations are not returned by API and must be simulated on frontend
+
+Important requirement:
+
+- pending simulated operations should match the real operation model closely enough for UI consistency
+
+# Rules
+
+- Preserve the frontend operation model unless the task explicitly changes it.
+- Prefer backend-provided values over old custom calculations when the new API supports them.
+- Keep decimals/amount formatting correct.
+- Do not reduce meaningful operation detail to generic labels when data exists.
+- Pending/fake operations must still carry enough fields for correct UI rendering.
+- Keep pagination/filter logic compatible with current UI behavior.
+- Avoid introducing special cases in components if the parser/model layer can solve it cleanly.
+
+# Workflow
+
+1. Find the current history model path.
+
+   - raw API response types
+   - parsers/mappers
+   - history utils
+   - pending operation creation logic
+   - UI components that consume normalized operations
+
+2. Compare real API shape vs expected frontend shape.
+
+   - identify missing fields
+   - identify renamed fields
+   - identify deprecated custom calculations
+
+3. Update model normalization.
+
+   - map amount
+   - map status
+   - map type
+   - map timestamps
+   - map operation ids/hash
+   - map `networkFees`
+   - preserve any UI-required derived fields
+
+4. Update pending/fake operation builders.
+
+   - match the normalized structure as closely as possible
+   - include correctly formatted amount and fees
+   - ensure delegation/stake/unstake are distinguishable and not collapsed into vague labels like `Staking` when richer info should exist
+
+5. Validate filter and pagination behavior.
+
+   - ensure selected filters are passed with cursor requests if required
+   - ensure empty next page stops loading
+   - avoid infinite loading loops
+
+6. Validate grouping behavior.
+   - operations sharing hash may need grouping under one item depending on current frontend pattern
+   - keep grouping logic consistent with existing dev branch behavior if referenced
+
+# Output expectations
+
+For implementation tasks:
+
+- update types and normalization logic
+- explain model differences briefly
+- mention any UI behavior preserved intentionally
+
+For bug analysis:
+
+- point to exact mismatch between backend payload and parser expectations
+- describe whether the fix belongs in parser, pending builder, or pagination/filter logic
+
+# Mavryk-specific guidance
+
+- `networkFees.totalFee`, `gasFee`, `storageFee`, and `burnedFromFees` should replace old custom fee derivation where the new API provides them.
+- Keep operation amount and fee decimal handling accurate.
+- Pending operations are simulated because API does not return them, so their model must be intentionally aligned with the normalized real operation model.
+- Group batched operations by hash if that is the existing intended wallet behavior.
+- Filters like `reveal`, `interaction`, `origination`, etc. should not break pagination or trigger infinite requests.
+- Empty result for next page should stop further loading and surface “no more results” behavior if the UI supports it.
+
+# Things to double-check
+
+- amount decimals
+- fee decimals
+- pending operation labels
+- grouping by hash
+- cursor + filter together
+- infinite scroll stop condition
+- unsupported/missing backend operation types
+- status mapping
+- operation role/source/destination consistency where relevant

--- a/.codex/skills/pr-creator/SKILL.md
+++ b/.codex/skills/pr-creator/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: pr-creator
+description: Use this when preparing commits and creating or updating a pull request for the current branch with a clean title, proper base branch, and structured summary.
+---
+
+# Purpose
+
+Use this skill when:
+
+- preparing commits before push
+- creating a new PR
+- updating an existing PR for the current branch
+- generating a clean PR title and description
+
+# Rules
+
+- Be concise and factual
+- Follow conventional commit style
+- Group related changes logically
+- Do not include unrelated changes in one PR
+- Do not rewrite history unless explicitly requested
+- Do not guess base branch — detect or ask if unclear
+- Prefer updating an existing PR for the current branch instead of creating a new one
+- Prefer current working branch pattern (e.g. MAV-xxxx/dev)
+
+# Workflow
+
+1. Detect current branch
+
+   - use git branch
+   - confirm it is a feature branch
+
+2. Check whether an open PR already exists for the current branch
+
+   - if yes, update the existing PR title/body
+   - if no, continue with PR creation flow
+
+3. Determine base branch
+
+   - try to detect from:
+     - existing branch naming patterns
+     - previous PRs
+   - if unclear → ask user
+   - fallback: use provided default (e.g. MAV-3661/dev)
+
+4. Prepare commits
+
+   - group changes logically
+   - use conventional commits:
+     - feat:
+     - fix:
+     - refactor:
+     - chore:
+   - avoid vague commit messages
+
+5. Generate PR title
+
+   - format:
+     [TASK-ID] short description
+
+6. Generate PR description
+
+   Structure:
+
+   ## Summary
+
+   - what was done
+
+   ## Changes
+
+   - main changes
+
+   ## Technical details
+
+   - important implementation notes
+
+   ## Risks
+
+   - edge cases or potential issues
+
+   ## Test plan
+
+   - how to verify
+
+7. Create or update PR
+
+   If CLI is available:
+
+   - if PR exists:
+     - use `gh pr edit`
+   - if PR does not exist:
+     - use `gh pr create --base <base> --head <current-branch> --title "<title>" --body "<description>"`
+
+   If CLI is not available:
+
+   - output the title, description, and command for the user
+
+# PR title format
+
+[TASK-ID] short description
+
+Example:
+MAV-3661: update wallet API parsing and auth flow fixes
+
+# PR description format
+
+## Summary
+
+- short overview
+
+## Changes
+
+- main changes
+
+## Technical details
+
+- implementation notes
+
+## Risks
+
+- possible edge cases
+
+## Test plan
+
+- how to verify
+
+# CLI guidance
+
+To detect PR state for current branch:
+
+- use `gh pr view`
+
+To update existing PR:
+
+- use `gh pr edit`
+
+To create new PR:
+
+- use `gh pr create --base <base> --head <current-branch>`
+
+If base branch is not provided and cannot be detected safely, ask for it instead of guessing.

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -3571,7 +3571,7 @@
     "message": "Add or Import Account"
   },
   "addOrImportAccountDescfiption": {
-    "message": " Here you can create a brand new account, import an old account you currently use on a different platform or restore an account you no longer have access to but have kept the seed phrase or keystore file."
+    "message": "Choose how you'd like to set up your account. You can create a new one, bring in an existing account, or recover one you've lost access to."
   },
   "addNewAccount": {
     "message": "Add New Account"

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -3571,7 +3571,7 @@
     "message": "Add or Import Account"
   },
   "addOrImportAccountDescfiption": {
-    "message": " Here you can create a brand new account, import an old account you currently use on a different platform or restore an account you no longer have access to but have kept the seed phrase or keystore file."
+    "message": "Choose how you'd like to set up your account. You can create a new one, bring in an existing account, or recover one you've lost access to."
   },
   "addNewAccount": {
     "message": "Add New Account"

--- a/src/app/atoms/Name.tsx
+++ b/src/app/atoms/Name.tsx
@@ -1,18 +1,46 @@
-import React, { FC, HTMLAttributes } from 'react';
+import React, { FC, HTMLAttributes, useMemo } from 'react';
 
 import classNames from 'clsx';
+import { Props } from 'tippy.js';
 
 import { setTestID, TestIDProps } from 'lib/analytics';
+import useTippy, { UseTippyOptions } from 'lib/ui/useTippy';
 
-type NameProps = HTMLAttributes<HTMLDivElement> & TestIDProps;
+type NameProps = HTMLAttributes<HTMLDivElement> &
+  TestIDProps & {
+    tooltipContent?: Props['content'];
+  };
 
-const Name: FC<NameProps> = ({ className, style = {}, testID, ...rest }) => (
-  <div
-    className={classNames('whitespace-nowrap overflow-x-auto truncate no-scrollbar', className)}
-    style={{ maxWidth: '8rem', ...style }}
-    {...setTestID(testID)}
-    {...rest}
-  />
-);
+const isTextTruncated = (element: HTMLElement) =>
+  element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+
+const Name: FC<NameProps> = ({ className, style = {}, testID, tooltipContent, ...rest }) => {
+  const tippyProps = useMemo<UseTippyOptions>(
+    () => ({
+      trigger: 'mouseenter',
+      hideOnClick: false,
+      content: tooltipContent,
+      animation: 'shift-away-subtle',
+      onShow(instance) {
+        const reference = instance.reference;
+
+        return Boolean(tooltipContent) && reference instanceof HTMLElement && isTextTruncated(reference);
+      }
+    }),
+    [tooltipContent]
+  );
+
+  const ref = useTippy<HTMLDivElement>(tippyProps);
+
+  return (
+    <div
+      ref={tooltipContent ? ref : undefined}
+      className={classNames('whitespace-nowrap overflow-x-auto truncate no-scrollbar', className)}
+      style={{ maxWidth: '8rem', ...style }}
+      {...setTestID(testID)}
+      {...rest}
+    />
+  );
+};
 
 export default Name;

--- a/src/app/defaults.ts
+++ b/src/app/defaults.ts
@@ -9,7 +9,7 @@ export class NotEnoughFundsError extends ArtificialError {}
 export class ZeroBalanceError extends NotEnoughFundsError {}
 export class ZeroTEZBalanceError extends NotEnoughFundsError {}
 
-export const ACCOUNT_NAME_PATTERN_STR = '^(?! )[\\p{L}\\p{N} ]{1,16}(?<! )$';
+export const ACCOUNT_NAME_PATTERN_STR = '^(?! )[\\p{L}\\p{N}\\p{Emoji} .\\-]{1,100}(?<! )$';
 export const ACCOUNT_NAME_PATTERN = new RegExp(ACCOUNT_NAME_PATTERN_STR, 'u');
 
 export const ACCOUNT_OR_GROUP_NAME_PATTERN = /^[^!@#$%^&*()_+\-=\]{};':"\\|,.<>?]{1,16}$/;

--- a/src/app/icons/account-card-add.svg
+++ b/src/app/icons/account-card-add.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 5V19" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  <path d="M5 12H19" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/src/app/icons/account-card-import.svg
+++ b/src/app/icons/account-card-import.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 16.5V18C6 19.1046 6.89543 20 8 20H16C17.1046 20 18 19.1046 18 18V16.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+  <path d="M12 4V14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+  <path d="M8.5 10.5L12 14L15.5 10.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/app/icons/account-card-restore.svg
+++ b/src/app/icons/account-card-restore.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M18.5 8.5C17.3063 6.11048 14.8395 4.5 12 4.5C7.85786 4.5 4.5 7.85786 4.5 12C4.5 16.1421 7.85786 19.5 12 19.5C15.0233 19.5 17.6289 17.7111 18.8143 15.1333"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+  <path d="M18.5 4.5V8.5H14.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/app/layouts/PageLayout/Header/AccountPopup/index.tsx
+++ b/src/app/layouts/PageLayout/Header/AccountPopup/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useState, useEffect } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 
 import classNames from 'clsx';
 
@@ -41,7 +41,7 @@ const AccountPopup: FC<AccountPopupProps> = ({ opened, setOpened }) => {
   const plusTippyOptions = useMemo<UseTippyOptions>(
     () => ({
       ...settingsTippyOptions,
-      content: 'Import Account'
+      content: 'Add or Import Account'
     }),
     [settingsTippyOptions]
   );
@@ -50,8 +50,6 @@ const AccountPopup: FC<AccountPopupProps> = ({ opened, setOpened }) => {
   const plusRef = useTippy<HTMLAnchorElement>(plusTippyOptions);
 
   const [searchValue, setSearchValue] = useState('');
-  const [attractSelectedAccount, setAttractSelectedAccount] = useState(true);
-
   const filteredAccounts = useMemo(() => {
     if (searchValue.length === 0) {
       return allAccounts;
@@ -73,11 +71,6 @@ const AccountPopup: FC<AccountPopupProps> = ({ opened, setOpened }) => {
     },
     [account, setAccountPkh, setOpened]
   );
-
-  useEffect(() => {
-    if (searchValue) setAttractSelectedAccount(false);
-    else if (opened === false) setAttractSelectedAccount(true);
-  }, [opened, searchValue]);
 
   const icons = useMemo(() => {
     return [

--- a/src/app/pages/AddOrImportAccount/AddOrImportAccount.tsx
+++ b/src/app/pages/AddOrImportAccount/AddOrImportAccount.tsx
@@ -116,7 +116,7 @@ export const AddOrImportAccount: FC = () => {
       <div
         className={clsx('w-full mx-auto h-full flex flex-col justify-start', popup ? 'max-w-sm' : 'max-w-screen-xxs')}
       >
-        <p className="mb-4 text-sm text-white leading-none">
+        <p className="mb-4 text-sm text-cleanWhite leading-none">
           <T id="addOrImportAccountDescfiption" />
         </p>
         <div className="flex flex-col gap-3 items-stretch pb-4">
@@ -147,20 +147,20 @@ const AddOrImportAccountCard: FC<AddOrImportAccountCardProps> = ({ route, hovere
         className="mb-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
         style={{ backgroundColor: route.theme.accentColor }}
       >
-        <route.Icon className="h-6 w-6 text-white" />
+        <route.Icon className="h-6 w-6 text-cleanWhite" />
       </div>
 
       <div className="flex flex-col gap-2 w-full">
-        <p className="text-sm font-bold text-white leading-none">
+        <p className="text-sm font-bold text-cleanWhite leading-none capitalize">
           <T id={route.i18nKey} />
         </p>
 
-        <p className="text-sm text-white leading-none">{route.description}</p>
+        <p className="text-sm text-cleanWhite leading-none">{route.description}</p>
 
         {route.tags?.length ? (
           <div className="flex flex-wrap gap-1">
             {route.tags.map(tag => (
-              <span key={tag} className="rounded px-1 py-0.5 text-white" style={BADGE_STYLE}>
+              <span key={tag} className="rounded px-1 py-0.5 text-cleanWhite" style={BADGE_STYLE}>
                 <span className="text-xs" style={BADGE_COPY_STYLE}>
                   <T id={tag} />
                 </span>

--- a/src/app/pages/AddOrImportAccount/AddOrImportAccount.tsx
+++ b/src/app/pages/AddOrImportAccount/AddOrImportAccount.tsx
@@ -1,63 +1,197 @@
-import React, { FC } from 'react';
+import React, { CSSProperties, FC, useMemo, useState } from 'react';
 
 import clsx from 'clsx';
 
 import { useAppEnv } from 'app/env';
+import { ReactComponent as AddAccountIcon } from 'app/icons/account-card-add.svg';
+import { ReactComponent as ImportAccountIcon } from 'app/icons/account-card-import.svg';
+import { ReactComponent as RestoreAccountIcon } from 'app/icons/account-card-restore.svg';
 import PageLayout from 'app/layouts/PageLayout';
-import { ButtonRounded } from 'app/molecules/ButtonRounded';
 import { T, TID } from 'lib/i18n';
+import { useRelevantAccounts } from 'lib/temple/front';
+import { useAccount, useHDGroups } from 'lib/temple/front/ready';
+import { TempleAccountType } from 'lib/temple/types';
 import { Link } from 'lib/woozie';
+import { useAccountsGroups } from 'mavryk/front/groups';
 
 type BtnRoute = {
+  key: string;
   i18nKey: TID;
-  linkTo: string;
+  description: string;
+  linkTo?: string;
+  onClick?: EmptyFn;
+  disabled?: boolean;
+  tags?: TID[];
+  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  theme: {
+    accentColor: string;
+    borderColor: string;
+    hoverColor: string;
+  };
 };
 
-const buttonRoutes: BtnRoute[] = [
-  {
-    i18nKey: 'addNewAccount',
-    linkTo: '/create-account'
-  },
-  {
-    i18nKey: 'importAccount',
-    linkTo: '/import-account'
-  },
-  {
-    i18nKey: 'restoreAccount',
-    linkTo: '/import-wallet'
-  }
-];
+const BADGE_COPY_STYLE: CSSProperties = {
+  letterSpacing: '-0.24px',
+  lineHeight: '12px'
+};
+
+const BADGE_STYLE: CSSProperties = {
+  backgroundColor: 'rgba(255, 255, 255, 0.15)'
+};
+
+const baseCardClassName =
+  'w-full rounded-lg border p-4 text-left transition duration-200 ease-in-out focus:outline-none';
+
+const getCardStyle = (route: BtnRoute, isHovered: boolean): CSSProperties => ({
+  backgroundColor: '#010101',
+  borderColor: isHovered ? route.theme.hoverColor : route.theme.borderColor,
+  boxShadow: isHovered ? `0 0 4px ${route.theme.hoverColor}` : 'none',
+  opacity: route.disabled ? 0.6 : 1
+});
 
 export const AddOrImportAccount: FC = () => {
   const { popup } = useAppEnv();
-  return (
-    <PageLayout
-      pageTitle={
-        <>
-          <T id="addOrImportAccount" />
-        </>
+  const currentAccount = useAccount();
+  const allAccounts = useRelevantAccounts();
+  const hdGroups = useHDGroups();
+  const groups = useAccountsGroups(allAccounts);
+
+  const [hoveredRouteKey, setHoveredRouteKey] = useState<string | null>(null);
+
+  const currentWalletId = useMemo(
+    () => (currentAccount.type === TempleAccountType.HD ? currentAccount.walletId : hdGroups[0]?.id),
+    [currentAccount, hdGroups]
+  );
+
+  const currentGroup = useMemo(() => groups.find(group => group.id === currentWalletId), [currentWalletId, groups]);
+
+  const buttonRoutes = useMemo<BtnRoute[]>(
+    () => [
+      {
+        key: 'add-account',
+        i18nKey: 'addNewAccount',
+        description:
+          'Create a new sub-account linked to your current wallet. Perfect for organising funds or separating activities.',
+        linkTo: '/create-account',
+        disabled: !currentWalletId || !currentGroup,
+        Icon: AddAccountIcon,
+        theme: {
+          accentColor: '#AB58FF',
+          borderColor: 'rgba(171, 88, 255, 0.5)',
+          hoverColor: 'rgba(171, 88, 255, 0.75)'
+        }
+      },
+      {
+        key: 'import-account',
+        i18nKey: 'importAccount',
+        description: 'Bring in an account you already use on another platform or device.',
+        linkTo: '/import-account',
+        tags: ['privateKey', 'seedPhrase', 'fundraiser', 'managedKTAccount', 'watchOnlyAccount'],
+        Icon: ImportAccountIcon,
+        theme: {
+          accentColor: '#F958FF',
+          borderColor: 'rgba(249, 88, 255, 0.5)',
+          hoverColor: 'rgba(249, 88, 255, 0.75)'
+        }
+      },
+      {
+        key: 'restore-account',
+        i18nKey: 'restoreAccount',
+        description: 'Recover an account you no longer have access to using your backup credentials.',
+        linkTo: '/import-wallet',
+        tags: ['seedPhrase', 'keystoreFile'],
+        Icon: RestoreAccountIcon,
+        theme: {
+          accentColor: '#58BFFF',
+          borderColor: 'rgba(88, 191, 255, 0.5)',
+          hoverColor: 'rgba(88, 191, 255, 0.75)'
+        }
       }
-      isTopbarVisible={false}
-    >
+    ],
+    [currentGroup, currentWalletId]
+  );
+
+  return (
+    <PageLayout pageTitle={<T id="addOrImportAccount" />} isTopbarVisible={false}>
       <div
-        className={clsx(
-          'w-full mx-auto h-full flex flex-col justify-start pb-8',
-          popup ? 'max-w-sm' : 'max-w-screen-xxs'
-        )}
+        className={clsx('w-full mx-auto h-full flex flex-col justify-start', popup ? 'max-w-sm' : 'max-w-screen-xxs')}
       >
-        <div className="text-sm text-white mb-20">
+        <p className="mb-4 text-sm text-white leading-none">
           <T id="addOrImportAccountDescfiption" />
-        </div>
-        <div className="flex flex-col gap-4 items-stretch">
-          {buttonRoutes.map(btn => (
-            <Link to={btn.linkTo} key={btn.linkTo} className="w-full">
-              <ButtonRounded size="big" fill={false} className="w-full capitalize">
-                <T id={btn.i18nKey} />
-              </ButtonRounded>
-            </Link>
+        </p>
+        <div className="flex flex-col gap-3 items-stretch pb-4">
+          {buttonRoutes.map(route => (
+            <AddOrImportAccountCard
+              key={route.key}
+              route={route}
+              hovered={hoveredRouteKey === route.key}
+              onHoverChange={setHoveredRouteKey}
+            />
           ))}
         </div>
       </div>
     </PageLayout>
+  );
+};
+
+type AddOrImportAccountCardProps = {
+  route: BtnRoute;
+  hovered: boolean;
+  onHoverChange: (routeKey: string | null) => void;
+};
+
+const AddOrImportAccountCard: FC<AddOrImportAccountCardProps> = ({ route, hovered, onHoverChange }) => {
+  const content = (
+    <>
+      <div
+        className="mb-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+        style={{ backgroundColor: route.theme.accentColor }}
+      >
+        <route.Icon className="h-6 w-6 text-white" />
+      </div>
+
+      <div className="flex flex-col gap-2 w-full">
+        <p className="text-sm font-bold text-white leading-none">
+          <T id={route.i18nKey} />
+        </p>
+
+        <p className="text-sm text-white leading-none">{route.description}</p>
+
+        {route.tags?.length ? (
+          <div className="flex flex-wrap gap-1">
+            {route.tags.map(tag => (
+              <span key={tag} className="rounded px-1 py-0.5 text-white" style={BADGE_STYLE}>
+                <span className="text-xs" style={BADGE_COPY_STYLE}>
+                  <T id={tag} />
+                </span>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+
+  const commonProps = {
+    className: clsx(baseCardClassName, 'flex flex-col items-start', route.disabled && 'cursor-not-allowed'),
+    onMouseEnter: () => onHoverChange(route.key),
+    onMouseLeave: () => onHoverChange(null),
+    onFocus: () => onHoverChange(route.key),
+    onBlur: () => onHoverChange(null),
+    style: getCardStyle(route, hovered)
+  };
+
+  if (route.linkTo) {
+    return (
+      <Link to={route.linkTo} {...commonProps}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" {...commonProps} onClick={route.onClick} disabled={route.disabled}>
+      {content}
+    </button>
   );
 };

--- a/src/app/pages/EditAccount/EditAccount.tsx
+++ b/src/app/pages/EditAccount/EditAccount.tsx
@@ -217,7 +217,9 @@ export const EditContact: FC<EditAccountProps> = ({ accHash }) => {
             <div className="z-10 flex flex-col items-center">
               <Identicon type="bottts" hash={accountHash} size={64} className="shadow-xs rounded-full flex-shrink-0" />
               <div className="text-white flex items-center gap-1 mb-2 mt-3">
-                <Name className="text-primary-white text-xl">{accountName}</Name>
+                <Name tooltipContent={accToChange?.name} className="text-primary-white text-xl">
+                  {accountName}
+                </Name>
 
                 <button onClick={editNamePopup.open} className="outline-none focus:outline-none">
                   <EditIcon className="min-w-6 w-6 h-6 fill-current" />

--- a/src/app/pages/Home/OtherComponents/Tokens/Tokens.tsx
+++ b/src/app/pages/Home/OtherComponents/Tokens/Tokens.tsx
@@ -26,6 +26,7 @@ import { SortOptions, useSortededAssetsSlugs } from 'lib/assets/use-sorted';
 import { useCurrentAccountBalances } from 'lib/balances';
 import { T } from 'lib/i18n';
 import { useAccount, useChainId } from 'lib/temple/front';
+import { TempleAccountType } from 'lib/temple/types';
 import { useLocalStorage } from 'lib/ui/local-storage';
 import { navigate } from 'lib/woozie';
 
@@ -44,7 +45,7 @@ export const TokensTab: FC = () => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const chainId = useChainId(true)!;
   const balances = useCurrentAccountBalances();
-  const { publicKeyHash } = useAccount();
+  const { publicKeyHash, type } = useAccount();
 
   const isSyncing = useAreAssetsLoading('tokens');
   const { popup } = useAppEnv();
@@ -221,11 +222,12 @@ export const TokensTab: FC = () => {
           </>
         </SearchExplorer>
       </div>
-
       {/* {isEnabledAdsBanner && <AcceptAdsBanner />} */}
-      <div className={clsx('mb-4', popup && 'px-4')}>
-        <StakeTezosTag />
-      </div>
+      {type !== TempleAccountType.WatchOnly && (
+        <div className={clsx('mb-4', popup && 'px-4')}>
+          <StakeTezosTag />
+        </div>
+      )}
 
       {sortedSlugs.length === 0 ? (
         <div className="pt-20 pb-8 flex flex-col items-center justify-center text-white">
@@ -246,7 +248,6 @@ export const TokensTab: FC = () => {
           />
         </div>
       )}
-
       {isSyncing && <SyncSpinner className="mt-4" />}
     </div>
   );

--- a/src/app/pages/ManageAccounts/ManageAccounts.tsx
+++ b/src/app/pages/ManageAccounts/ManageAccounts.tsx
@@ -61,7 +61,10 @@ export const ManageAccounts: FC = () => {
             cleanButtonStyle={{ backgroundColor: 'transparent' }}
             onValueChange={setSearchValue}
           />
-          <Link to="import-account" className="flex items-center justify-center w-8 h-8 rounded-lg bg-secondary-card">
+          <Link
+            to="/add-or-import-account"
+            className="flex items-center justify-center w-8 h-8 rounded-lg bg-secondary-card"
+          >
             <PlusIcon className="w-6 h-6 stroke-2" />
           </Link>
         </div>

--- a/src/app/pages/ManageAccounts/components/WalletCardDropdown/WalletCardDropdown.tsx
+++ b/src/app/pages/ManageAccounts/components/WalletCardDropdown/WalletCardDropdown.tsx
@@ -5,71 +5,16 @@ import { nanoid } from 'nanoid';
 
 import { ReactComponent as PenIcon } from 'app/icons/edit-title.svg';
 import { ReactComponent as EyeIcon } from 'app/icons/eye-open-secondary.svg';
-import { ReactComponent as PlusIcon } from 'app/icons/plus.svg';
 import { SuccessStateType } from 'app/pages/SuccessScreen/SuccessScreen';
 import { DropdownSelect } from 'app/templates/DropdownSelect/DropdownSelect';
-import { ACCOUNT_EXISTS_SHOWN_WARNINGS_STORAGE_KEY } from 'lib/constants';
-import { useStorage, useTempleClient } from 'lib/temple/front';
-import { useHDGroups } from 'lib/temple/front/ready';
-import { DisplayedGroup, TempleAccount } from 'lib/temple/types';
-import { useAlert } from 'lib/ui';
 import { translateYModifiersNegative } from 'lib/ui/general-modifiers';
 import { navigate } from 'lib/woozie';
 
 type WalletCardDropdownProps = {
-  group: DisplayedGroup;
-  handleRenameClick: (group: DisplayedGroup) => void;
-  showAccountAlreadyExistsWarning: (group: DisplayedGroup, oldAccount: TempleAccount) => void;
+  handleRenameClick: EmptyFn;
 };
 
-export const WalletCardDropdown: FC<WalletCardDropdownProps> = ({
-  group,
-  showAccountAlreadyExistsWarning,
-  handleRenameClick
-}) => {
-  const { id: walletId } = group;
-  const { createAccount, findFreeHdIndex } = useTempleClient();
-  const hdGroups = useHDGroups();
-  const customAlert = useAlert();
-
-  const [accountExistsShownWarnings, setAccountExistsShownWarnings] = useStorage<Record<string, boolean>>(
-    ACCOUNT_EXISTS_SHOWN_WARNINGS_STORAGE_KEY,
-    {}
-  );
-
-  const addAccount = useCallback(async () => {
-    try {
-      const { firstSkippedAccount } = await findFreeHdIndex(walletId);
-      if (firstSkippedAccount && !accountExistsShownWarnings[walletId]) {
-        showAccountAlreadyExistsWarning(group, firstSkippedAccount);
-        setAccountExistsShownWarnings(prevState => ({
-          ...Object.fromEntries(
-            Object.entries(prevState).filter(([groupId]) => !hdGroups.some(({ id }) => id === groupId))
-          ),
-          [walletId]: true
-        }));
-      } else {
-        await createAccount(walletId);
-      }
-    } catch (e: any) {
-      console.error(e);
-      customAlert({
-        title: 'Failed to create an account',
-        description: e.message
-      });
-    }
-  }, [
-    accountExistsShownWarnings,
-    createAccount,
-    customAlert,
-    findFreeHdIndex,
-    group,
-    hdGroups,
-    setAccountExistsShownWarnings,
-    showAccountAlreadyExistsWarning,
-    walletId
-  ]);
-
+export const WalletCardDropdown: FC<WalletCardDropdownProps> = ({ handleRenameClick }) => {
   const revesalSeedPhrase = useCallback(() => {
     navigate<SuccessStateType>('/success', undefined, {
       pageTitle: 'revealSeedPhrase',
@@ -85,15 +30,9 @@ export const WalletCardDropdown: FC<WalletCardDropdownProps> = ({
     () => [
       {
         id: nanoid(),
-        Icon: PlusIcon,
-        label: 'Add Account',
-        onClick: addAccount
-      },
-      {
-        id: nanoid(),
         label: 'Rename Wallet',
         Icon: PenIcon,
-        onClick: () => handleRenameClick(group)
+        onClick: handleRenameClick
       },
       {
         id: nanoid(),
@@ -102,7 +41,7 @@ export const WalletCardDropdown: FC<WalletCardDropdownProps> = ({
         onClick: revesalSeedPhrase
       }
     ],
-    [addAccount, group, handleRenameClick, revesalSeedPhrase]
+    [handleRenameClick, revesalSeedPhrase]
   );
 
   return (

--- a/src/app/pages/ManageAccounts/components/index.tsx
+++ b/src/app/pages/ManageAccounts/components/index.tsx
@@ -1,10 +1,7 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
-import { useTempleClient } from 'lib/temple/front';
-import { DisplayedGroup, TempleAccount } from 'lib/temple/types';
-import { useAlert } from 'lib/ui/dialog';
+import { DisplayedGroup } from 'lib/temple/types';
 
-import { AccountAlreadyExistsWarning } from '../popups/AccountAlreadyExistsWarning';
 import { EditWalletGroupNamePopup } from '../popups/EditWalletGroupNamePopup';
 
 import { WalletCardDropdown } from './WalletCardDropdown/WalletCardDropdown';
@@ -13,98 +10,21 @@ type AccountsmanagementProps = {
   group: DisplayedGroup;
 };
 
-enum AccountsManagementModal {
-  RenameWallet = 'rename-wallet',
-  ConfirmSeedPhraseAccess = 'confirm-seed-phrase-access',
-  RevealSeedPhrase = 'reveal-seed-phrase',
-  DeleteWallet = 'delete-wallet',
-  AccountAlreadyExistsWarning = 'account-already-exists-warning',
-  CreateHDWalletFlow = 'create-hd-wallet-flow',
-  ImportAccount = 'import-account',
-  ImportWallet = 'import-wallet',
-  WatchOnly = 'watch-only',
-  ConnectLedger = 'connect-ledger'
-}
-
 export const Accountsmanagement: FC<AccountsmanagementProps> = ({ group }) => {
-  const { createAccount } = useTempleClient();
-  const customAlert = useAlert();
-
-  const [selectedGroup, setSelectedGroup] = useState<DisplayedGroup | null>(null);
-  const [oldAccount, setOldAccount] = useState<TempleAccount | null>(null);
-  const [activeModal, setActiveModal] = useState<AccountsManagementModal | null>(null);
+  const [isRenameWalletPopupOpen, setIsRenameWalletPopupOpen] = useState(false);
 
   const handleModalClose = useCallback(() => {
-    setActiveModal(null);
-    setSelectedGroup(null);
-    setOldAccount(null);
+    setIsRenameWalletPopupOpen(false);
   }, []);
 
-  const actionWithModalFactory = useCallback(
-    (modal: AccountsManagementModal) => (group: DisplayedGroup) => {
-      setSelectedGroup(group);
-      setActiveModal(modal);
-    },
-    []
-  );
-
-  const handleRenameClick = useMemo(
-    () => actionWithModalFactory(AccountsManagementModal.RenameWallet),
-    [actionWithModalFactory]
-  );
-
-  const showAccountAlreadyExistsWarning = useCallback((group: DisplayedGroup, oldAccount: TempleAccount) => {
-    setSelectedGroup(group);
-    setOldAccount(oldAccount);
-    setActiveModal(AccountsManagementModal.AccountAlreadyExistsWarning);
+  const handleRenameClick = useCallback(() => {
+    setIsRenameWalletPopupOpen(true);
   }, []);
-
-  const handleAccountAlreadyExistsWarnClose = useCallback(async () => {
-    try {
-      await createAccount(selectedGroup!.id);
-      handleModalClose();
-    } catch (e: any) {
-      console.error(e);
-      customAlert({
-        title: 'Failed to create an account',
-        description: e.message
-      });
-    }
-  }, [createAccount, customAlert, handleModalClose, selectedGroup]);
-
-  const modal = useMemo(() => {
-    switch (activeModal) {
-      case AccountsManagementModal.RenameWallet:
-        return (
-          <EditWalletGroupNamePopup
-            group={selectedGroup!}
-            opened={activeModal === AccountsManagementModal.RenameWallet}
-            close={handleModalClose}
-          />
-        );
-
-      case AccountsManagementModal.AccountAlreadyExistsWarning:
-        return (
-          <AccountAlreadyExistsWarning
-            newAccountGroup={selectedGroup!}
-            oldAccount={oldAccount!}
-            onClose={handleAccountAlreadyExistsWarnClose}
-          />
-        );
-
-      default:
-        return null;
-    }
-  }, [activeModal, handleAccountAlreadyExistsWarnClose, handleModalClose, oldAccount, selectedGroup]);
 
   return (
     <>
-      <WalletCardDropdown
-        group={group}
-        showAccountAlreadyExistsWarning={showAccountAlreadyExistsWarning}
-        handleRenameClick={handleRenameClick}
-      />
-      {modal}
+      <WalletCardDropdown handleRenameClick={handleRenameClick} />
+      {isRenameWalletPopupOpen && <EditWalletGroupNamePopup group={group} opened close={handleModalClose} />}
     </>
   );
 };

--- a/src/app/pages/ManageStake/screens/DecreaseStake.tsx
+++ b/src/app/pages/ManageStake/screens/DecreaseStake.tsx
@@ -18,7 +18,7 @@ import { T, t, toLocalFixed } from 'lib/i18n';
 import { MAVEN_METADATA, useAssetMetadata } from 'lib/metadata';
 import { useAccount, useChainId, useTezos } from 'lib/temple/front';
 import { useAccountDelegatePeriodStats } from 'lib/temple/front/baking';
-import { atomsToTokens, tokensToAtoms } from 'lib/temple/helpers';
+import { atomsToTokens } from 'lib/temple/helpers';
 import { buildPendingOperationObject, putOperationIntoStorage } from 'lib/temple/history/utils';
 import { TempleAccountType } from 'lib/temple/types';
 import { useSafeState } from 'lib/ui/hooks';
@@ -133,7 +133,7 @@ export const DecreaseStake: FC = () => {
           operation: op,
           type: 'staking',
           sender: account.publicKeyHash,
-          amount: tokensToAtoms(amount, assetMetadata?.decimals ?? MAVEN_METADATA.decimals).toString(),
+          amount: new BigNumber(amount).toNumber(),
           estimation: estmtn,
           baker: myBakerPkh,
           kind: 'unstake'

--- a/src/app/pages/ManageStake/screens/IncreaseStake.tsx
+++ b/src/app/pages/ManageStake/screens/IncreaseStake.tsx
@@ -19,7 +19,7 @@ import { T, t, toLocalFixed } from 'lib/i18n';
 import { MAVEN_METADATA, useAssetMetadata } from 'lib/metadata';
 import { useAccount, useChainId, useTezos } from 'lib/temple/front';
 import { useAccountDelegatePeriodStats } from 'lib/temple/front/baking';
-import { atomsToTokens, tokensToAtoms } from 'lib/temple/helpers';
+import { atomsToTokens } from 'lib/temple/helpers';
 import { buildPendingOperationObject, putOperationIntoStorage } from 'lib/temple/history/utils';
 import { TempleAccountType } from 'lib/temple/types';
 import { useSafeState } from 'lib/ui/hooks';
@@ -169,7 +169,7 @@ export const IncreaseStake = () => {
           operation: op,
           type: 'staking',
           sender: account.publicKeyHash,
-          amount: tokensToAtoms(amount, assetMetadata?.decimals ?? MAVEN_METADATA.decimals).toString(),
+          amount: amtBN.toNumber(),
           estimation: estimation,
           baker: myBakerPkh,
           kind: 'stake'

--- a/src/app/pages/Stake/DelegateForm.tsx
+++ b/src/app/pages/Stake/DelegateForm.tsx
@@ -376,7 +376,8 @@ const DelegateForm: FC<DelegateFormProps> = ({
           to,
           newDelegate: to,
           prevDelegate: myBakerPkh,
-          estimation: estmtn
+          estimation: estmtn,
+          feeMumav: acc.type === TempleAccountType.ManagedKT ? undefined : fee
         });
         if (pendingOpObject) await putOperationIntoStorage(chainId, accountPkh, pendingOpObject);
 
@@ -713,6 +714,7 @@ export const DelegateActionsComponent: FC<{ avtivateReDelegation: () => void }> 
           operation: op,
           type: 'staking',
           sender: account.publicKeyHash,
+          amount: atomsToTokens(unstakedBalance ?? 0, MAVEN_METADATA.decimals).toNumber(),
           estimation: estmtn,
           baker: myBakerPkh,
           kind: 'finalize_unstake'

--- a/src/app/templates/Contacts/Contacts.tsx
+++ b/src/app/templates/Contacts/Contacts.tsx
@@ -126,7 +126,9 @@ const ContactContent: React.FC<
       >
         <div className="flex flex-col justify-between flex-1">
           <div className="flex items-center">
-            <Name className="mb-px text-base-plus text-white text-left">{item.name}</Name>
+            <Name tooltipContent={item.name} className="mb-px text-base-plus text-white text-left">
+              {item.name}
+            </Name>
             <ContactsBadge own={item.accountInWallet} isCurrent={account.publicKeyHash === item.address} />
           </div>
 

--- a/src/app/templates/Contacts/screens/AddContact.tsx
+++ b/src/app/templates/Contacts/screens/AddContact.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import clsx from 'clsx';
 import { useForm } from 'react-hook-form';
@@ -9,7 +9,14 @@ import { useAppEnv } from 'app/env';
 import { ButtonRounded } from 'app/molecules/ButtonRounded';
 import { SuccessStateType } from 'app/pages/SuccessScreen/SuccessScreen';
 import { t, T } from 'lib/i18n';
-import { isDomainNameValid, useTezosDomainsClient, useContactsActions } from 'lib/temple/front';
+import {
+  isDomainNameValid,
+  useContactsActions,
+  useKnownBakers,
+  useNetwork,
+  useTezosDomainsClient
+} from 'lib/temple/front';
+import { PREDEFINED_BAKERS_NAMES_MAINNET } from 'lib/temple/front/baking/const';
 import { isAddressValid } from 'lib/temple/helpers';
 import { delay } from 'lib/utils';
 import { HistoryAction, goBack, navigate, useLocation } from 'lib/woozie';
@@ -34,8 +41,11 @@ const SUBMIT_ERROR_TYPE = 'submit-error';
 
 const AddNewContactForm: React.FC<{ className?: string }> = ({ className }) => {
   const { addContact } = useContactsActions();
+  const network = useNetwork();
+  const knownBakers = useKnownBakers(false);
   const domainsClient = useTezosDomainsClient();
   const { historyPosition, pathname } = useLocation();
+  const autofilledValidatorNameRef = useRef<string | null>(null);
 
   const {
     register,
@@ -44,6 +54,7 @@ const AddNewContactForm: React.FC<{ className?: string }> = ({ className }) => {
     formState,
     clearError,
     setError,
+    setValue,
     errors,
     watch
   } = useForm<ContactFormData>();
@@ -51,10 +62,84 @@ const AddNewContactForm: React.FC<{ className?: string }> = ({ className }) => {
   const submitting = formState.isSubmitting;
   const name = watch('name') ?? '';
   const address = watch('address') ?? '';
+  const knownValidatorAddresses = useMemo(
+    () => new Set((knownBakers ?? []).map(({ address: bakerAddress }) => bakerAddress)),
+    [knownBakers]
+  );
 
   const inHome = pathname === '/';
   const isSubmitDisabled = !name.length || !address.length;
   const properHistoryPosition = historyPosition > 0 || !inHome;
+
+  // Keep the contact name aligned with the entered validator address by resolving domains
+  // and applying the predefined validator label. Cleanup only ignores stale async lookups.
+  useEffect(() => {
+    let cancelled = false;
+
+    const syncValidatorName = async () => {
+      const trimmedAddress = address.trim();
+      const previousAutofilledName = autofilledValidatorNameRef.current;
+
+      if (!trimmedAddress) {
+        if (previousAutofilledName && name === previousAutofilledName) {
+          setValue('name', '');
+        }
+
+        autofilledValidatorNameRef.current = null;
+
+        return;
+      }
+
+      let resolvedAddress = trimmedAddress;
+
+      if (isDomainNameValid(trimmedAddress, domainsClient)) {
+        const resolved = await domainsClient.resolver.resolveNameToAddress(trimmedAddress);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (!resolved) {
+          resolvedAddress = '';
+        } else {
+          resolvedAddress = resolved;
+        }
+      }
+
+      const validatorName =
+        network.type === 'main' && knownValidatorAddresses.has(resolvedAddress)
+          ? PREDEFINED_BAKERS_NAMES_MAINNET[resolvedAddress]?.name ?? null
+          : null;
+
+      if (cancelled) {
+        return;
+      }
+
+      if (validatorName) {
+        if (!name || name === previousAutofilledName) {
+          if (name !== validatorName) {
+            setValue('name', validatorName);
+          }
+
+          autofilledValidatorNameRef.current = validatorName;
+        }
+
+        return;
+      }
+
+      if (previousAutofilledName && name === previousAutofilledName) {
+        setValue('name', '');
+      }
+
+      autofilledValidatorNameRef.current = null;
+    };
+
+    syncValidatorName();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, domainsClient, knownValidatorAddresses, name, network.type, setValue]);
 
   const onCancelSubmit = useCallback(() => {
     if (submitting) return;

--- a/src/app/templates/History/History.tsx
+++ b/src/app/templates/History/History.tsx
@@ -121,19 +121,19 @@ export const HistoryComponent: React.FC<Props> = memo(
                 selected: filterOptions.includes(HistoryItemOpTypeEnum.Reveal),
 
                 nameI18nKey: 'reveal'
-              },
-              {
-                id: HistoryItemOpTypeEnum.Swap.toString(),
-                selected: filterOptions.includes(HistoryItemOpTypeEnum.Swap),
-
-                nameI18nKey: 'swap'
-              },
-              {
-                id: HistoryItemOpTypeEnum.Other.toString(),
-                selected: filterOptions.includes(HistoryItemOpTypeEnum.Other),
-
-                nameI18nKey: 'other'
               }
+              // {
+              //   id: HistoryItemOpTypeEnum.Swap.toString(),
+              //   selected: filterOptions.includes(HistoryItemOpTypeEnum.Swap),
+
+              //   nameI18nKey: 'swap'
+              // },
+              // {
+              //   id: HistoryItemOpTypeEnum.Other.toString(),
+              //   selected: filterOptions.includes(HistoryItemOpTypeEnum.Other),
+
+              //   nameI18nKey: 'other'
+              // }
             ] as SortListItemType[]))
       ],
       [assetSlug, filterOptions]

--- a/src/app/templates/History/HistoryDetailsPopup.tsx
+++ b/src/app/templates/History/HistoryDetailsPopup.tsx
@@ -41,6 +41,7 @@ import {
   alterIpfsUrl,
   deriveStatusColorClassName,
   getAssetsFromOperations,
+  getHistoryOperationAddress,
   getMoneyDiffForMultiple,
   getMoneyDiffsForSwap
 } from './utils';
@@ -375,7 +376,7 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
       case HistoryItemOpTypeEnum.Delegation:
         const opDelegate = item as HistoryItemDelegationOp;
 
-        const delegateAddress = opDelegate.newDelegate?.address || opDelegate.source.address;
+        const delegateAddress = getHistoryOperationAddress(opDelegate, historyItem);
         const delegateBaker = getPredefinedBaker(delegateAddress);
 
         return {
@@ -386,7 +387,7 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
       case HistoryItemOpTypeEnum.Staking:
         const opStaking = item as HistoryItemStakingOp;
 
-        const stakingAddress = opStaking.baker?.address || opStaking.sender?.address || opStaking.source.address;
+        const stakingAddress = getHistoryOperationAddress(opStaking, historyItem);
         const stakingBaker = getPredefinedBaker(stakingAddress);
 
         return {
@@ -399,13 +400,13 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
         const opOriginate = item as HistoryItemOriginationOp;
         return {
           label: HistoryItemTypeLabels[historyItem.type],
-          address: opOriginate.originatedContract?.address
+          address: getHistoryOperationAddress(opOriginate, historyItem)
         };
 
       case HistoryItemOpTypeEnum.Interaction:
         const opInteract = item as HistoryItemTransactionOp;
 
-        const interactionAddress = opInteract.destination.address;
+        const interactionAddress = getHistoryOperationAddress(opInteract, historyItem);
         const interactionBaker = getPredefinedBaker(interactionAddress);
         return {
           label: HistoryItemTypeLabels[historyItem.type],
@@ -417,13 +418,13 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
 
         return {
           label: HistoryItemTypeLabels[historyItem.type],
-          address: opSwap.destination.address
+          address: getHistoryOperationAddress(opSwap, historyItem)
         };
 
       case HistoryItemOpTypeEnum.TransferFrom:
         const opFrom = item as HistoryItemTransactionOp;
 
-        const transferFromAddress = opFrom.source.address;
+        const transferFromAddress = getHistoryOperationAddress(opFrom, historyItem);
         const transferFromBaker = getPredefinedBaker(transferFromAddress);
         return {
           label: HistoryItemTypeLabels[historyItem.type],
@@ -434,7 +435,7 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
       case HistoryItemOpTypeEnum.TransferTo:
         const opTo = item as HistoryItemTransactionOp;
 
-        const transferToAddress = opTo.destination.address;
+        const transferToAddress = getHistoryOperationAddress(opTo, historyItem);
         const transferToBaker = getPredefinedBaker(transferToAddress);
         return {
           label: HistoryItemTypeLabels[historyItem.type],
@@ -445,14 +446,14 @@ const TxAddressBlock: FC<{ historyItem: UserHistoryItem }> = ({ historyItem }) =
         const opReveal = item as HistoryItemTransactionOp;
         return {
           label: HistoryItemTypeLabels[historyItem.type],
-          address: opReveal.destination.address
+          address: getHistoryOperationAddress(opReveal, historyItem)
         };
 
       // Other
       default:
         const opOther = item as HistoryItemOtherOp;
 
-        const otherAddress = opOther.destination?.address || opOther.source.address || opOther.hash;
+        const otherAddress = getHistoryOperationAddress(opOther, historyItem);
         const otherBaker = getPredefinedBaker(otherAddress);
 
         return {

--- a/src/app/templates/History/OperStackItem.tsx
+++ b/src/app/templates/History/OperStackItem.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lib/temple/history/types';
 
 import { MoneyDiffView } from './MoneyDiffView';
-import { getAssetsFromOperations, getStakingMessage } from './utils';
+import { getAssetsFromOperations, getHistoryOperationAddress, getStakingMessage } from './utils';
 
 interface Props {
   item: IndividualHistoryItem;
@@ -123,6 +123,7 @@ export const OpertionStackItem = memo<Props>(({ item, isTiny, moneyDiff, origina
 
     case HistoryItemOpTypeEnum.Interaction:
       const opInteract = item as HistoryItemTransactionOp;
+      const interactionAddress = getHistoryOperationAddress(opInteract, originalHistoryItem);
 
       return (
         <Component
@@ -131,16 +132,14 @@ export const OpertionStackItem = memo<Props>(({ item, isTiny, moneyDiff, origina
           argsNode={
             <StackItemArgs
               i18nKey="interactionOnContract"
-              args={[
-                <span className="text-accent-blue">{opInteract.entrypoint}</span>,
-                (opInteract.destination?.address ?? opInteract.source?.address) || opInteract.hash
-              ]}
+              args={[<span className="text-accent-blue">{opInteract.entrypoint}</span>, interactionAddress]}
             />
           }
         />
       );
     case HistoryItemOpTypeEnum.Multiple:
       const opMultiple = item as HistoryItemTransactionOp;
+      const multipleAddress = getHistoryOperationAddress(opMultiple, originalHistoryItem);
       return (
         <Component
           {...componentBaseProps}
@@ -149,7 +148,7 @@ export const OpertionStackItem = memo<Props>(({ item, isTiny, moneyDiff, origina
             <StackItemArgs
               i18nKey="multipleInteractionOnContract"
               args={[
-                opMultiple.destination.address,
+                multipleAddress,
                 <span>{originalHistoryItem ? originalHistoryItem?.operations.length - 1 : 1} more</span>
               ]}
             />
@@ -177,30 +176,33 @@ export const OpertionStackItem = memo<Props>(({ item, isTiny, moneyDiff, origina
 
     case HistoryItemOpTypeEnum.TransferFrom:
       const opFrom = item as HistoryItemTransactionOp;
+      const transferFromAddress = getHistoryOperationAddress(opFrom, originalHistoryItem);
       return (
         <Component
           {...componentBaseProps}
           titleNode={HistoryItemOpTypeTexts[item.type]}
-          argsNode={<StackItemArgs i18nKey="transferFromSmb" args={[opFrom.source.address]} />}
+          argsNode={<StackItemArgs i18nKey="transferFromSmb" args={[transferFromAddress]} />}
         />
       );
 
     case HistoryItemOpTypeEnum.TransferTo:
       const opTo = item as HistoryItemTransactionOp;
+      const transferToAddress = getHistoryOperationAddress(opTo, originalHistoryItem);
       return (
         <Component
           {...componentBaseProps}
           titleNode={HistoryItemOpTypeTexts[item.type]}
-          argsNode={<StackItemArgs i18nKey="transferToSmb" args={[opTo.destination?.address ?? 'unkwonn']} />}
+          argsNode={<StackItemArgs i18nKey="transferToSmb" args={[transferToAddress]} />}
         />
       );
     case HistoryItemOpTypeEnum.Reveal:
       const opReveal = item as HistoryItemTransactionOp;
+      const revealAddress = getHistoryOperationAddress(opReveal, originalHistoryItem);
       return (
         <Component
           {...componentBaseProps}
           titleNode={HistoryItemOpTypeTexts[item.type]}
-          argsNode={<StackItemArgs i18nKey="revealOperationType" args={[opReveal.source.address]} />}
+          argsNode={<StackItemArgs i18nKey="revealOperationType" args={[revealAddress]} />}
         />
       );
     // Other
@@ -225,7 +227,7 @@ export const OpertionStackItem = memo<Props>(({ item, isTiny, moneyDiff, origina
             <StackItemArgs
               // using reveal i18n to get empty string
               i18nKey="revealOperationType"
-              args={[opOther.destination?.address || opOther.source.address || opOther.hash]}
+              args={[getHistoryOperationAddress(opOther, originalHistoryItem)]}
             />
           }
         />

--- a/src/app/templates/History/utils.ts
+++ b/src/app/templates/History/utils.ts
@@ -5,10 +5,15 @@ import { t } from 'lib/i18n';
 import { getPredefinedBakerProperty } from 'lib/temple/front/baking/utils';
 import { isZero, MoneyDiff } from 'lib/temple/history/helpers';
 import {
+  HistoryItemDelegationOp,
   HistoryItemOpTypeEnum,
+  HistoryItemOriginationOp,
+  HistoryItemOtherOp,
   HistoryItemStatus,
+  HistoryItemStakingOp,
   HistoryItemTransactionOp,
   StakingActions,
+  IndividualHistoryItem,
   UserHistoryItem
 } from 'lib/temple/history/types';
 
@@ -74,6 +79,71 @@ export function getAssetsFromOperations(item: UserHistoryItem | null | undefined
 
   return slugs;
 }
+
+const getTransactionTargetAddress = (operation?: Partial<HistoryItemTransactionOp>) =>
+  operation?.destination?.address ?? operation?.tokenTransfers?.recipients?.[0]?.to.address;
+
+export const getHistoryOperationAddress = (
+  item: IndividualHistoryItem | null | undefined,
+  originalHistoryItem?: UserHistoryItem
+) => {
+  if (!item) return '';
+
+  switch (item.type) {
+    case HistoryItemOpTypeEnum.Delegation: {
+      const delegationOp = item as HistoryItemDelegationOp;
+
+      return (
+        delegationOp.newDelegate?.address ??
+        delegationOp.prevDelegate?.address ??
+        delegationOp.source.address ??
+        delegationOp.hash
+      );
+    }
+
+    case HistoryItemOpTypeEnum.Staking: {
+      const stakingOp = item as HistoryItemStakingOp;
+
+      return stakingOp.baker?.address ?? stakingOp.sender?.address ?? stakingOp.source.address ?? stakingOp.hash;
+    }
+
+    case HistoryItemOpTypeEnum.Origination: {
+      const originationOp = item as HistoryItemOriginationOp;
+
+      return originationOp.originatedContract?.address ?? originationOp.source.address ?? originationOp.hash;
+    }
+
+    case HistoryItemOpTypeEnum.TransferFrom:
+      return item.source.address ?? getTransactionTargetAddress(item as HistoryItemTransactionOp) ?? item.hash;
+
+    case HistoryItemOpTypeEnum.TransferTo:
+    case HistoryItemOpTypeEnum.Interaction:
+    case HistoryItemOpTypeEnum.Swap: {
+      const txOp = item as HistoryItemTransactionOp;
+
+      return getTransactionTargetAddress(txOp) ?? txOp.source.address ?? txOp.hash;
+    }
+
+    case HistoryItemOpTypeEnum.Multiple: {
+      const groupedOperation =
+        originalHistoryItem?.operations.find(operation =>
+          getTransactionTargetAddress(operation as HistoryItemTransactionOp)
+        ) ?? originalHistoryItem?.operations[0];
+
+      return getHistoryOperationAddress(groupedOperation, undefined) || item.source.address || item.hash;
+    }
+
+    case HistoryItemOpTypeEnum.Reveal:
+      return item.source.address ?? item.hash;
+
+    case HistoryItemOpTypeEnum.Other:
+    default: {
+      const otherOp = item as HistoryItemOtherOp;
+
+      return otherOp.destination?.address ?? otherOp.source.address ?? otherOp.hash;
+    }
+  }
+};
 
 export function getMoneyDiffsForSwap(moneyDiffs: MoneyDiff[]) {
   const diff = [...moneyDiffs.filter(m => !new BigNumber(m.diff).isZero())];

--- a/src/app/templates/SendForm/ContactsDropdownItem.tsx
+++ b/src/app/templates/SendForm/ContactsDropdownItem.tsx
@@ -44,7 +44,9 @@ const ContactsDropdownItem: FC<ContactsDropdownItemProps> = ({ contact, active, 
 
       <div className="ml-2 flex flex-1 w-full">
         <div className="flex flex-col justify-between flex-1">
-          <Name className="text-base-plus text-white text-left">{contact.name}</Name>
+          <Name tooltipContent={contact.name} className="text-base-plus text-white text-left">
+            {contact.name}
+          </Name>
 
           <span
             className={classNames('text-sm font-light text-white')}
@@ -96,7 +98,9 @@ export const ContactsDropdownItemSecondary: FC<ContactsDropdownItemProps> = ({ c
       <div className="ml-2 flex flex-1 w-full relative">
         <div className="flex flex-col justify-between flex-1">
           <div className="flex items-center gap-1">
-            <Name className="text-base-plus text-white text-left">{contact.name}</Name>
+            <Name tooltipContent={contact.name} className="text-base-plus text-white text-left">
+              {contact.name}
+            </Name>
 
             {contact.accountInWallet ? (
               <div className="flex items-center">

--- a/src/app/templates/SendForm/Form.tsx
+++ b/src/app/templates/SendForm/Form.tsx
@@ -408,8 +408,10 @@ export const Form: FC<FormProps> = ({ assetSlug, operation, setOperation, onAddC
             type: 'transaction',
             sender: acc.publicKeyHash,
             estimation: estmtn,
-            amount: tokensToAtoms(actualAmount, assetMetadata?.decimals).toString(),
-            to: toResolved
+            amount: actualAmount,
+            to: toResolved,
+            assetSlug,
+            feeMumav: fee
           });
           if (pendingOpObject) await putOperationIntoStorage(chainId, acc.publicKeyHash, pendingOpObject);
         }

--- a/src/lib/temple/back/actions.ts
+++ b/src/lib/temple/back/actions.ts
@@ -62,7 +62,7 @@ import {
 } from './store';
 import { Vault } from './vault';
 
-export const ACCOUNT_NAME_PATTERN_STR = '^(?! )[\\p{L}\\p{N} ]{1,16}(?<! )$';
+export const ACCOUNT_NAME_PATTERN_STR = '^(?! )[\\p{L}\\p{N}\\p{Emoji} .\\-]{1,100}(?<! )$';
 export const ACCOUNT_NAME_PATTERN = new RegExp(ACCOUNT_NAME_PATTERN_STR, 'u');
 const ACCOUNT_OR_GROUP_NAME_PATTERN = /^[^!@#$%^&*()_+\-=\]{};':"\\|,.<>?]{1,16}$/;
 

--- a/src/lib/temple/back/actions.ts
+++ b/src/lib/temple/back/actions.ts
@@ -12,7 +12,7 @@ import { ACCOUNT_PKH_STORAGE_KEY } from 'lib/constants';
 import { BACKGROUND_IS_WORKER } from 'lib/env';
 import { addLocalOperation } from 'lib/temple/activity';
 import * as Beacon from 'lib/temple/beacon';
-import { getAuthWalletAddress, loadChainId } from 'lib/temple/helpers';
+import { buildAuthWalletAddressesMap, loadChainId, resolveAuthWalletAddress } from 'lib/temple/helpers';
 import {
   TempleState,
   TempleMessageType,
@@ -34,6 +34,7 @@ import {
   requestAuthChallenge,
   verifyAuthSignature
 } from 'mavryk/api';
+import { setAuthWalletAddressesMapToStorage } from 'mavryk/api/storage';
 import { signAuthChallengeWithVault } from 'mavryk/api/utils';
 
 import {
@@ -79,21 +80,12 @@ const findNewAccount = (prev: TempleAccount[], next: TempleAccount[]) => {
   return next.find(acc => !prevIds.has(acc.id));
 };
 
-const isSignableAccount = (account: TempleAccount) =>
-  account.type !== TempleAccountType.WatchOnly && account.type !== TempleAccountType.ManagedKT;
+const syncAuthWalletAddresses = (accounts: TempleAccount[]) =>
+  setAuthWalletAddressesMapToStorage(buildAuthWalletAddressesMap(accounts));
 
-const resolveAuthWalletAddress = (accounts: TempleAccount[], accountPkh?: string) => {
-  if (accountPkh) {
-    const selectedAccount = accounts.find(acc => acc.publicKeyHash === accountPkh);
-
-    if (selectedAccount && isSignableAccount(selectedAccount)) {
-      return getAuthWalletAddress(accounts, accountPkh);
-    }
-  }
-
-  const fallbackAccount = accounts.find(isSignableAccount);
-
-  return fallbackAccount ? getAuthWalletAddress(accounts, fallbackAccount.publicKeyHash) : null;
+const updateAccountsAndSyncAuth = async (accounts: TempleAccount[]) => {
+  accountsUpdated(accounts);
+  await syncAuthWalletAddresses(accounts);
 };
 
 const getStoredSelectedAccountPkh = async () => {
@@ -220,6 +212,7 @@ export function unlock(password: string) {
       const accounts = await vault.fetchAccounts();
       const settings = await vault.fetchSettings();
       unlocked({ vault, accounts, settings });
+      await syncAuthWalletAddresses(accounts);
 
       const [selectedAccountPkh, networkId] = await Promise.all([
         getStoredSelectedAccountPkh(),
@@ -248,6 +241,7 @@ export async function unlockFromSession() {
     const accounts = await vault.fetchAccounts();
     const settings = await vault.fetchSettings();
     unlocked({ vault, accounts, settings });
+    await syncAuthWalletAddresses(accounts);
   });
 }
 
@@ -266,7 +260,7 @@ export function createHDAccount(walletId: string, name?: string, hdIndex?: numbe
 
     const prevAccounts = await vault.fetchAccounts();
     const updatedAccounts = await vault.createHDAccount(walletId, name, hdIndex);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
     const newAccount = findNewAccount(prevAccounts, updatedAccounts);
     if (newAccount) {
       await performAuthForAccount(vault, newAccount.publicKeyHash, updatedAccounts);
@@ -298,7 +292,7 @@ export function removeAccount(id: string, password: string) {
       console.error(err);
     }
     const { newAccounts } = await Vault.removeAccount(id, password);
-    accountsUpdated(newAccounts);
+    await updateAccountsAndSyncAuth(newAccounts);
   });
 }
 
@@ -317,7 +311,7 @@ export function editAccount(accPublicKeyHash: string, name: string) {
 export function updateAccountKYC(accPublicKeyHash: string, isKYC: boolean) {
   return withUnlocked(async ({ vault }) => {
     const updatedAccounts = await vault.updateAccountKYCStatus(accPublicKeyHash, isKYC);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
   });
 }
 
@@ -325,7 +319,7 @@ export function importAccount(chainId: string, chain: TempleChainKind, privateKe
   return withUnlocked(async ({ vault }) => {
     const prevAccounts = await vault.fetchAccounts();
     const updatedAccounts = await vault.importAccount(chain, chainId, privateKey, encPassword);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
     const newAccount = findNewAccount(prevAccounts, updatedAccounts);
     if (newAccount) {
       await performAuthForAccount(vault, newAccount.publicKeyHash, updatedAccounts);
@@ -337,7 +331,7 @@ export function importMnemonicAccount(mnemonic: string, chainId: string, passwor
   return withUnlocked(async ({ vault }) => {
     const prevAccounts = await vault.fetchAccounts();
     const updatedAccounts = await vault.importMnemonicAccount(mnemonic, chainId, password, derivationPath);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
     const newAccount = findNewAccount(prevAccounts, updatedAccounts);
     if (newAccount) {
       await performAuthForAccount(vault, newAccount.publicKeyHash, updatedAccounts);
@@ -348,14 +342,14 @@ export function importMnemonicAccount(mnemonic: string, chainId: string, passwor
 export function importFundraiserAccount(email: string, password: string, mnemonic: string, chainId: string) {
   return withUnlocked(async ({ vault }) => {
     const updatedAccounts = await vault.importFundraiserAccount(email, password, mnemonic, chainId);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
   });
 }
 
 export function importManagedKTAccount(address: string, chainId: string, owner: string) {
   return withUnlocked(async ({ vault }) => {
     const updatedAccounts = await vault.importManagedKTAccount(address, chainId, owner);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
   });
 }
 
@@ -363,7 +357,7 @@ export function importWatchOnlyAccount(address: string, chain: TempleChainKind, 
   return withUnlocked(async ({ vault }) => {
     const prevAccounts = await vault.fetchAccounts();
     const updatedAccounts = await vault.importWatchOnlyAccount(chain, address, chainId, name);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
     const newAccount = findNewAccount(prevAccounts, updatedAccounts);
     if (newAccount) {
       await performAuthForAccount(vault, newAccount.publicKeyHash, updatedAccounts);
@@ -374,7 +368,7 @@ export function importWatchOnlyAccount(address: string, chain: TempleChainKind, 
 export function createLedgerAccount(input: SaveLedgerAccountInput) {
   return withUnlocked(async ({ vault }) => {
     const updatedAccounts = await vault.createLedgerAccount(input);
-    accountsUpdated(updatedAccounts);
+    await updateAccountsAndSyncAuth(updatedAccounts);
   });
 }
 
@@ -394,14 +388,14 @@ export function removeHdWallet(id: string, password: string) {
       console.error(err);
     }
     const { newAccounts } = await Vault.removeHdWallet(id, password);
-    accountsUpdated(newAccounts);
+    await updateAccountsAndSyncAuth(newAccounts);
   });
 }
 
 export function removeAccountsByType(type: Exclude<TempleAccountType, TempleAccountType.HD>, password: string) {
   return withUnlocked(async () => {
     const newAccounts = await Vault.removeAccountsByType(type, password);
-    accountsUpdated(newAccounts);
+    await updateAccountsAndSyncAuth(newAccounts);
   });
 }
 
@@ -409,7 +403,7 @@ export function createOrImportWallet(mnemonic?: string) {
   return withUnlocked(async ({ vault }) => {
     const prevAccounts = await vault.fetchAccounts();
     const { newAccounts } = await vault.createOrImportWallet(mnemonic);
-    accountsUpdated(newAccounts);
+    await updateAccountsAndSyncAuth(newAccounts);
     const newAccount = findNewAccount(prevAccounts, newAccounts);
     if (newAccount) {
       await performAuthForAccount(vault, newAccount.publicKeyHash, newAccounts);

--- a/src/lib/temple/front/address-book.ts
+++ b/src/lib/temple/front/address-book.ts
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { ACCOUNT_NAME_PATTERN } from 'app/defaults';
 import { getMessage } from 'lib/i18n';
-import { TempleContact } from 'lib/temple/types';
+import { TempleContact, TempleContactApiType } from 'lib/temple/types';
 import { fetchContactsRecord, saveContactsRecord } from 'mavryk/api/contacts';
 
-import { isAddressValid } from '../helpers';
+import { isAddressValid, isKTAddress } from '../helpers';
 
+import { useKnownBakers } from './baking/baking';
+import { PREDEFINED_BAKERS_NAMES_MAINNET } from './baking/const';
 import { useTempleClient } from './client';
 import {
   buildContactsSettingsPatch,
@@ -21,22 +23,89 @@ import {
 import { useAccount, useAllAccounts, useNetwork, useSettings } from './ready';
 import { useFilteredContacts } from './use-filtered-contacts.hook';
 
+function isPredefinedValidatorAddress(address: string) {
+  return PREDEFINED_BAKERS_NAMES_MAINNET[address] !== undefined;
+}
+
 export function useContactsActions() {
   const { ensureAuthorized, revealPublicKey, updateSettings } = useTempleClient();
   const account = useAccount();
   const allAccounts = useAllAccounts();
   const network = useNetwork();
+  const knownBakers = useKnownBakers(false);
   const settings = useSettings();
   const { allContacts } = useFilteredContacts();
   const settingsRef = useRef(settings);
   const contactsOwnerAddress = getContactsOwnerAddress(allAccounts, account.publicKeyHash);
   const contactsStorageKey = buildContactsStorageKey(contactsOwnerAddress, network.id);
+  const knownValidatorAddresses = useMemo(
+    () => new Set((knownBakers ?? []).map(({ address }) => address)),
+    [knownBakers]
+  );
 
   // Keep the latest settings available for contact actions without rebuilding callbacks.
   // No cleanup is needed because this only updates an in-memory ref.
   useEffect(() => {
     settingsRef.current = settings;
   }, [settings]);
+
+  const isKnownValidatorAddress = useCallback(
+    (address: string) =>
+      knownValidatorAddresses.has(address) || (network.type === 'main' && isPredefinedValidatorAddress(address)),
+    [knownValidatorAddresses, network.type]
+  );
+
+  const detectContactType = useCallback(
+    (address: string, fallbackType: TempleContactApiType = 'user'): TempleContactApiType => {
+      if (isKTAddress(address)) {
+        return 'contract';
+      }
+
+      if (isKnownValidatorAddress(address)) {
+        return 'validator';
+      }
+
+      return fallbackType;
+    },
+    [isKnownValidatorAddress]
+  );
+
+  const resolveContact = useCallback(
+    (contact: Partial<TempleContact>, fallbackType?: TempleContactApiType) => {
+      const address = contact.address?.trim() ?? '';
+      const type = detectContactType(address, fallbackType);
+      const resolvedContact: TempleContact = {
+        address,
+        name: contact.name?.trim() ?? '',
+        ...(typeof contact.addedAt === 'number' ? { addedAt: contact.addedAt } : {})
+      };
+
+      return {
+        contact: resolvedContact,
+        type
+      };
+    },
+    [detectContactType]
+  );
+
+  const prepareContactsForPersistence = useCallback(
+    (contacts: TempleContact[], currentTypesByAddress?: Record<string, TempleContactApiType>) => {
+      const normalizedContacts = normalizeContacts(
+        contacts.map(contact => resolveContact(contact, currentTypesByAddress?.[contact.address.trim()]).contact)
+      );
+      const nextTypesByAddress = normalizedContacts.reduce<Record<string, TempleContactApiType>>((acc, contact) => {
+        acc[contact.address] = detectContactType(contact.address, currentTypesByAddress?.[contact.address] ?? 'user');
+
+        return acc;
+      }, {});
+
+      return {
+        contacts: normalizedContacts,
+        typesByAddress: Object.keys(nextTypesByAddress).length > 0 ? nextTypesByAddress : undefined
+      };
+    },
+    [detectContactType, resolveContact]
+  );
 
   const loadCurrentContactsState = useCallback(async () => {
     const currentSettings = settingsRef.current;
@@ -61,9 +130,12 @@ export function useContactsActions() {
       recordId = getStoredContactsRecordId(settingsRef.current, contactsStorageKey),
       typesByAddress = getStoredContactsTypesByAddress(settingsRef.current, contactsStorageKey)
     ) => {
-      const normalizedContacts = normalizeContacts(nextContacts);
+      const { contacts: normalizedContacts, typesByAddress: resolvedTypesByAddress } = prepareContactsForPersistence(
+        nextContacts,
+        typesByAddress
+      );
       let nextRecordId = recordId;
-      let nextTypesByAddress = typesByAddress;
+      let nextTypesByAddress = resolvedTypesByAddress;
 
       if (normalizedContacts.length > 0 || recordId) {
         if (!canUseEncryptedContacts(account.type)) {
@@ -76,7 +148,7 @@ export function useContactsActions() {
           contacts: normalizedContacts,
           publicKey,
           recordId,
-          typesByAddress
+          typesByAddress: resolvedTypesByAddress
         });
 
         nextRecordId = saved.recordId;
@@ -102,6 +174,7 @@ export function useContactsActions() {
       contactsStorageKey,
       ensureAuthorized,
       network.id,
+      prepareContactsForPersistence,
       revealPublicKey,
       updateSettings
     ]
@@ -117,26 +190,28 @@ export function useContactsActions() {
 
   const addContact = useCallback(
     async (cToAdd: TempleContact) => {
-      if (allContacts.some(c => c.address === cToAdd.address && c.accountInWallet)) {
+      const { contact } = resolveContact(cToAdd);
+
+      if (allContacts.some(c => c.address === contact.address && c.accountInWallet)) {
         throw new Error(getMessage('contactWithTheSameAddressAlreadyExists'));
       }
 
       await mutateContacts(sourceContacts => {
-        if (sourceContacts.some(c => c.address === cToAdd.address)) {
+        if (sourceContacts.some(c => c.address === contact.address)) {
           throw new Error(getMessage('contactWithTheSameAddressAlreadyExists'));
         }
 
-        return [cToAdd, ...sourceContacts];
+        return [contact, ...sourceContacts];
       });
     },
-    [allContacts, mutateContacts]
+    [allContacts, mutateContacts, resolveContact]
   );
 
   const addMultipleContacts = useCallback(
     async (rawContacts: Partial<TempleContact>[]) => {
       const normalized: TempleContact[] = rawContacts.map((c, i) => {
-        const name = c.name?.trim();
-        const address = c.address?.trim();
+        const { contact } = resolveContact(c);
+        const { name, address } = contact;
 
         // Required fields
         if (!name || !address) {
@@ -181,7 +256,7 @@ export function useContactsActions() {
         return [...unique, ...sourceContacts];
       });
     },
-    [allContacts, mutateContacts]
+    [allContacts, mutateContacts, resolveContact]
   );
 
   const removeContact = useCallback(

--- a/src/lib/temple/front/address-book.ts
+++ b/src/lib/temple/front/address-book.ts
@@ -37,7 +37,7 @@ export function useContactsActions() {
   const { allContacts } = useFilteredContacts();
   const settingsRef = useRef(settings);
   const contactsOwnerAddress = getContactsOwnerAddress(allAccounts, account.publicKeyHash);
-  const contactsStorageKey = buildContactsStorageKey(contactsOwnerAddress, network.id);
+  const contactsStorageKey = contactsOwnerAddress ? buildContactsStorageKey(contactsOwnerAddress, network.id) : null;
   const knownValidatorAddresses = useMemo(
     () => new Set((knownBakers ?? []).map(({ address }) => address)),
     [knownBakers]
@@ -109,45 +109,51 @@ export function useContactsActions() {
 
   const loadCurrentContactsState = useCallback(async () => {
     const currentSettings = settingsRef.current;
-    const cachedState = getCachedContactsState(currentSettings, contactsStorageKey);
+    const cachedState = contactsStorageKey ? getCachedContactsState(currentSettings, contactsStorageKey) : null;
 
     if (cachedState) {
       return cachedState;
     }
 
-    if (!canUseEncryptedContacts(account.type)) {
-      throw new Error('Encrypted contacts are unavailable for this account type');
+    if (!canUseEncryptedContacts(contactsOwnerAddress) || !contactsStorageKey) {
+      throw new Error('Encrypted contacts are unavailable for this account');
     }
 
     await ensureAuthorized(contactsOwnerAddress, network.id);
     const publicKey = await revealPublicKey(contactsOwnerAddress);
     return fetchContactsRecord(publicKey);
-  }, [account.type, contactsOwnerAddress, contactsStorageKey, ensureAuthorized, network.id, revealPublicKey]);
+  }, [contactsOwnerAddress, contactsStorageKey, ensureAuthorized, network.id, revealPublicKey]);
 
   const persistContacts = useCallback(
     async (
       nextContacts: TempleContact[],
-      recordId = getStoredContactsRecordId(settingsRef.current, contactsStorageKey),
-      typesByAddress = getStoredContactsTypesByAddress(settingsRef.current, contactsStorageKey)
+      recordId?: string | null,
+      typesByAddress?: Record<string, TempleContactApiType>
     ) => {
+      if (!canUseEncryptedContacts(contactsOwnerAddress) || !contactsStorageKey) {
+        throw new Error('Encrypted contacts are unavailable for this account');
+      }
+
+      const currentRecordId =
+        recordId === undefined ? getStoredContactsRecordId(settingsRef.current, contactsStorageKey) : recordId;
+      const currentTypesByAddress =
+        typesByAddress === undefined
+          ? getStoredContactsTypesByAddress(settingsRef.current, contactsStorageKey)
+          : typesByAddress;
       const { contacts: normalizedContacts, typesByAddress: resolvedTypesByAddress } = prepareContactsForPersistence(
         nextContacts,
-        typesByAddress
+        currentTypesByAddress
       );
-      let nextRecordId = recordId;
+      let nextRecordId = currentRecordId;
       let nextTypesByAddress = resolvedTypesByAddress;
 
-      if (normalizedContacts.length > 0 || recordId) {
-        if (!canUseEncryptedContacts(account.type)) {
-          throw new Error('Encrypted contacts are unavailable for this account type');
-        }
-
+      if (normalizedContacts.length > 0 || currentRecordId) {
         await ensureAuthorized(contactsOwnerAddress, network.id);
         const publicKey = await revealPublicKey(contactsOwnerAddress);
         const saved = await saveContactsRecord({
           contacts: normalizedContacts,
           publicKey,
-          recordId,
+          recordId: currentRecordId,
           typesByAddress: resolvedTypesByAddress
         });
 
@@ -169,7 +175,6 @@ export function useContactsActions() {
       );
     },
     [
-      account.type,
       contactsOwnerAddress,
       contactsStorageKey,
       ensureAuthorized,

--- a/src/lib/temple/front/contacts-settings.ts
+++ b/src/lib/temple/front/contacts-settings.ts
@@ -1,9 +1,8 @@
 import { isEqual } from 'lodash';
 
-import { getAuthWalletAddress } from 'lib/temple/helpers';
+import { resolveAuthWalletAddress } from 'lib/temple/helpers';
 import {
   TempleAccount,
-  TempleAccountType,
   TempleContact,
   TempleContactApiType,
   TempleContactsAccountState,
@@ -36,7 +35,7 @@ export function normalizeContacts(contacts: TempleContact[]) {
 }
 
 export function getContactsOwnerAddress(allAccounts: TempleAccount[], accountPkh: string) {
-  return getAuthWalletAddress(allAccounts, accountPkh);
+  return resolveAuthWalletAddress(allAccounts, accountPkh);
 }
 
 export function buildContactsStorageKey(walletAddress: string, networkId: string) {
@@ -129,6 +128,6 @@ export function hasContactsSettingsMismatch(
   );
 }
 
-export function canUseEncryptedContacts(accountType: TempleAccountType) {
-  return accountType !== TempleAccountType.WatchOnly && accountType !== TempleAccountType.ManagedKT;
+export function canUseEncryptedContacts(contactsOwnerAddress: string | null) {
+  return Boolean(contactsOwnerAddress);
 }

--- a/src/lib/temple/front/use-contacts-sync.hook.ts
+++ b/src/lib/temple/front/use-contacts-sync.hook.ts
@@ -28,7 +28,7 @@ export function useContactsSync(
     [account.publicKeyHash, allAccounts]
   );
   const contactsStorageKey = useMemo(
-    () => buildContactsStorageKey(contactsOwnerAddress, networkId),
+    () => (contactsOwnerAddress ? buildContactsStorageKey(contactsOwnerAddress, networkId) : null),
     [contactsOwnerAddress, networkId]
   );
 
@@ -41,7 +41,7 @@ export function useContactsSync(
   // Sync contacts for the selected auth wallet and network.
   // This manages remote contacts fetches; cleanup only cancels applying stale async results.
   useEffect(() => {
-    if (!canUseEncryptedContacts(account.type)) {
+    if (!canUseEncryptedContacts(contactsOwnerAddress) || !contactsStorageKey) {
       previousNetworkIdRef.current = networkId;
       return;
     }
@@ -81,13 +81,5 @@ export function useContactsSync(
     return () => {
       cancelled = true;
     };
-  }, [
-    account.type,
-    contactsOwnerAddress,
-    contactsStorageKey,
-    ensureAuthorized,
-    networkId,
-    revealPublicKey,
-    updateSettings
-  ]);
+  }, [contactsOwnerAddress, contactsStorageKey, ensureAuthorized, networkId, revealPublicKey, updateSettings]);
 }

--- a/src/lib/temple/front/use-filtered-contacts.hook.ts
+++ b/src/lib/temple/front/use-filtered-contacts.hook.ts
@@ -21,11 +21,18 @@ export function useFilteredContacts() {
   const account = useAccount();
   const allAccounts = useAllAccounts();
   const network = useNetwork();
-  const contactsStorageKey = useMemo(
-    () => buildContactsStorageKey(getContactsOwnerAddress(allAccounts, account.publicKeyHash), network.id),
-    [account.publicKeyHash, allAccounts, network.id]
+  const contactsOwnerAddress = useMemo(
+    () => getContactsOwnerAddress(allAccounts, account.publicKeyHash),
+    [account.publicKeyHash, allAccounts]
   );
-  const contacts = getCurrentAccountStoredContacts(settings, contactsStorageKey);
+  const contactsStorageKey = useMemo(
+    () => (contactsOwnerAddress ? buildContactsStorageKey(contactsOwnerAddress, network.id) : null),
+    [contactsOwnerAddress, network.id]
+  );
+  const contacts = useMemo(
+    () => (contactsStorageKey ? getCurrentAccountStoredContacts(settings, contactsStorageKey) : []),
+    [contactsStorageKey, settings]
+  );
 
   const accounts = useRelevantAccounts();
   const accountContacts = useMemo<TempleContact[]>(
@@ -54,6 +61,10 @@ export function useFilteredContacts() {
   // Keep the scoped contacts cache aligned with filtered contacts for the active wallet/network view.
   // No cleanup is needed because this is a one-shot settings synchronization.
   useEffect(() => {
+    if (!contactsStorageKey) {
+      return;
+    }
+
     if (!hasContactsSettingsMismatch(settings, contactsStorageKey, filteredContacts)) {
       return;
     }

--- a/src/lib/temple/helpers.ts
+++ b/src/lib/temple/helpers.ts
@@ -84,6 +84,10 @@ export function getSameGroupAccounts(allAccounts: TempleAccount[], accountType: 
   );
 }
 
+export function canAccountSignAuth(account: TempleAccount) {
+  return account.type !== TempleAccountType.WatchOnly && account.type !== TempleAccountType.ManagedKT;
+}
+
 /**
  * Resolves the canonical auth wallet address for the provided account.
  * HD sub-accounts share the index-0 address of the same wallet.
@@ -103,11 +107,30 @@ export function getAuthWalletAddress(allAccounts: TempleAccount[], accountPublic
 }
 
 /**
+ * Resolves the wallet address that should own Mavryk API auth for the provided account.
+ * Non-signable accounts reuse the first signable wallet available in the vault.
+ */
+export function resolveAuthWalletAddress(allAccounts: TempleAccount[], accountPublicKeyHash?: string | null) {
+  if (accountPublicKeyHash) {
+    const selectedAccount = allAccounts.find(account => account.publicKeyHash === accountPublicKeyHash);
+
+    if (selectedAccount && canAccountSignAuth(selectedAccount)) {
+      return getAuthWalletAddress(allAccounts, selectedAccount.publicKeyHash);
+    }
+  }
+
+  const fallbackAccount = allAccounts.find(canAccountSignAuth);
+
+  return fallbackAccount ? getAuthWalletAddress(allAccounts, fallbackAccount.publicKeyHash) : null;
+}
+
+/**
  * Builds a lookup from each account address to the auth wallet address used for Mavryk auth storage.
  */
 export function buildAuthWalletAddressesMap(allAccounts: TempleAccount[]) {
   return allAccounts.reduce<Record<string, string>>((result, account) => {
-    result[account.publicKeyHash] = getAuthWalletAddress(allAccounts, account.publicKeyHash);
+    result[account.publicKeyHash] =
+      resolveAuthWalletAddress(allAccounts, account.publicKeyHash) ?? account.publicKeyHash;
 
     return result;
   }, {});

--- a/src/lib/temple/history/fetch.ts
+++ b/src/lib/temple/history/fetch.ts
@@ -6,7 +6,7 @@ import { ReactiveTezosToolkit } from 'lib/temple/front';
 import { TempleAccount } from 'lib/temple/types';
 import { extractMavrykApiErrorMessage, fetchTokenHistory, fetchWalletHistory } from 'mavryk/api/history';
 
-import { getBackendHistoryFilters, getHistoryItemTypesFromParams } from './filterParams';
+import { getBackendHistoryFilters, getHistoryItemTypesFromParams, shouldApplyLocalTypeFilter } from './filterParams';
 import type { UserHistoryItem, OperationsGroup } from './types';
 import { HistoryItemOpTypeEnum } from './types';
 import {
@@ -116,56 +116,33 @@ export default async function fetchUserHistory(
   operationParams?: GetOperationsTransactionsParams
 ): Promise<FetchUserHistoryResult> {
   const requestedTypes = getHistoryItemTypesFromParams(account.publicKeyHash, operationParams);
-  const backendFilters = getBackendHistoryFilters(account.publicKeyHash, operationParams);
+  const backendFilter = getBackendHistoryFilters(account.publicKeyHash, operationParams);
+  const localRequestedTypes = shouldApplyLocalTypeFilter(operationParams) ? requestedTypes : [];
   const tokenAddress = getTokenAddressFromSlug(assetSlug);
   const isFirstPage = cursor == null;
 
   try {
-    let nextCursor = cursor;
-    let hasMore = true;
-    let normalizedItems: UserHistoryItem[] = [];
-    const collectedOperations: Awaited<ReturnType<typeof fetchWalletHistory>>['operations'] = [];
+    const response = tokenAddress
+      ? await fetchTokenHistory(tokenAddress, {
+          walletAddress: account.publicKeyHash,
+          cursor,
+          filter: backendFilter
+        })
+      : await fetchWalletHistory({
+          walletAddress: account.publicKeyHash,
+          cursor,
+          filter: backendFilter
+        });
 
-    while (hasMore) {
-      const response = tokenAddress
-        ? await fetchTokenHistory(tokenAddress, {
-            walletAddress: account.publicKeyHash,
-            cursor: nextCursor,
-            filter: backendFilters
-          })
-        : await fetchWalletHistory({
-            walletAddress: account.publicKeyHash,
-            cursor: nextCursor,
-            filter: backendFilters
-          });
-
-      collectedOperations.push(...response.operations);
-
-      normalizedItems = normalizeBackendHistoryItems(
-        collectedOperations,
-        account.publicKeyHash,
-        requestedTypes,
-        assetSlug
-      );
-      const lastVisibleHash = normalizedItems[Math.min(normalizedItems.length, pseudoLimit) - 1]?.hash;
-      const responseLastHash = response.operations[response.operations.length - 1]?.hash;
-      const shouldCompleteTrailingGroup =
-        Boolean(lastVisibleHash) && response.hasMore && responseLastHash === lastVisibleHash;
-
-      if (!response.hasMore || response.cursor == null || response.cursor === nextCursor) {
-        hasMore = false;
-        break;
-      }
-
-      nextCursor = response.cursor;
-      hasMore = true;
-
-      if (normalizedItems.length >= pseudoLimit && !shouldCompleteTrailingGroup) {
-        break;
-      }
-    }
-
+    const normalizedItems = normalizeBackendHistoryItems(
+      response.operations,
+      account.publicKeyHash,
+      localRequestedTypes,
+      assetSlug
+    );
     const visibleCollected = normalizedItems.slice(0, pseudoLimit);
+    const nextCursor = response.cursor;
+    const hasMore = response.hasMore;
 
     if (!isFirstPage) {
       return {

--- a/src/lib/temple/history/fetch.ts
+++ b/src/lib/temple/history/fetch.ts
@@ -5,6 +5,7 @@ import { fetchFromStorage, putToStorage } from 'lib/storage';
 import { ReactiveTezosToolkit } from 'lib/temple/front';
 import { TempleAccount } from 'lib/temple/types';
 import { extractMavrykApiErrorMessage, fetchTokenHistory, fetchWalletHistory } from 'mavryk/api/history';
+import type { MavrykHistoryOperation } from 'mavryk/api/history';
 
 import { getBackendHistoryFilters, getHistoryItemTypesFromParams, shouldApplyLocalTypeFilter } from './filterParams';
 import type { UserHistoryItem, OperationsGroup } from './types';
@@ -23,19 +24,32 @@ export type FetchUserHistoryResult = {
   hasMore: boolean;
 };
 
-function groupPendingOperations(operations: TzktOperation[]) {
+type PendingOperationGroupable = {
+  hash: string;
+  id?: number;
+};
+
+type LegacyPendingOperation = TzktOperation;
+
+function groupPendingOperations<T extends PendingOperationGroupable>(operations: T[]) {
   return Object.values(
-    operations.reduce<StringRecord<OperationsGroup>>((acc, item) => {
+    operations.reduce<StringRecord<{ hash: string; operations: T[] }>>((acc, item) => {
       if (!acc[item.hash]) {
         acc[item.hash] = { hash: item.hash, operations: [] };
       }
 
       acc[item.hash].operations.push(item);
-      acc[item.hash].operations.sort((a, b) => b.id - a.id);
+      acc[item.hash].operations.sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
 
       return acc;
     }, {})
   );
+}
+
+function isLegacyPendingOperation(
+  operation: CustomPendingOperation | LegacyPendingOperation
+): operation is LegacyPendingOperation {
+  return typeof (operation as LegacyPendingOperation).sender !== 'string';
 }
 
 function applyLocalTypeFilter(items: UserHistoryItem[], requestedTypes: HistoryItemOpTypeEnum[]) {
@@ -70,14 +84,32 @@ function normalizeBackendHistoryItems(
 
 async function fetchPendingHistoryItems(chainId: TzktApiChainId, account: TempleAccount) {
   const storageKey = buildStorageKeyForTx(account.publicKeyHash, chainId);
-  const pendingOperations = (await fetchFromStorage<CustomPendingOperation[]>(storageKey)) ?? [];
+  const pendingOperations =
+    (await fetchFromStorage<(CustomPendingOperation | LegacyPendingOperation)[]>(storageKey)) ?? [];
+  const legacyPendingOperations = pendingOperations.filter(isLegacyPendingOperation);
+  const backendPendingOperations = pendingOperations.filter(
+    (operation): operation is MavrykHistoryOperation => !isLegacyPendingOperation(operation)
+  );
+  const pendingItems = [
+    ...groupPendingOperations(backendPendingOperations).flatMap(group => {
+      const historyGroup = groupMavrykHistoryOperations(group.operations)[0];
+
+      return historyGroup ? [mavrykHistoryGroupToHistoryItem(historyGroup, { address: account.publicKeyHash })] : [];
+    }),
+    ...groupPendingOperations(legacyPendingOperations).map(group => {
+      const operationsGroup: OperationsGroup = {
+        hash: group.hash,
+        operations: group.operations
+      };
+
+      return operationsGroupToHistoryItem(operationsGroup, account.publicKeyHash);
+    })
+  ].sort((a, b) => b.addedAt.localeCompare(a.addedAt));
 
   return {
     storageKey,
     pendingOperations,
-    pendingItems: groupPendingOperations(pendingOperations as TzktOperation[]).map(group =>
-      operationsGroupToHistoryItem(group, account.publicKeyHash)
-    )
+    pendingItems
   };
 }
 

--- a/src/lib/temple/history/fetch.ts
+++ b/src/lib/temple/history/fetch.ts
@@ -12,11 +12,10 @@ import { HistoryItemOpTypeEnum } from './types';
 import {
   buildStorageKeyForTx,
   CustomPendingOperation,
+  groupMavrykHistoryOperations,
   mavrykHistoryGroupToHistoryItem,
   operationsGroupToHistoryItem
 } from './utils';
-
-const MAX_BACKEND_PAGE_SIZE = 20;
 
 export type FetchUserHistoryResult = {
   items: UserHistoryItem[];
@@ -52,6 +51,23 @@ function getTokenAddressFromSlug(assetSlug?: string) {
   return assetSlug.split('_')[0];
 }
 
+function normalizeBackendHistoryItems(
+  operations: ReturnType<typeof groupMavrykHistoryOperations>[number]['operations'],
+  accountAddress: string,
+  requestedTypes: HistoryItemOpTypeEnum[],
+  assetSlug?: string
+) {
+  return applyLocalTypeFilter(
+    groupMavrykHistoryOperations(operations).map(group =>
+      mavrykHistoryGroupToHistoryItem(group, {
+        address: accountAddress,
+        assetSlug
+      })
+    ),
+    requestedTypes
+  );
+}
+
 async function fetchPendingHistoryItems(chainId: TzktApiChainId, account: TempleAccount) {
   const storageKey = buildStorageKeyForTx(account.publicKeyHash, chainId);
   const pendingOperations = (await fetchFromStorage<CustomPendingOperation[]>(storageKey)) ?? [];
@@ -76,21 +92,14 @@ export async function fetchUserOperationByHash(
     const response = tokenAddress
       ? await fetchTokenHistory(tokenAddress, {
           walletAddress: accountAddress,
-          search: hash,
-          limit: 20
+          search: hash
         })
       : await fetchWalletHistory({
           walletAddress: accountAddress,
-          search: hash,
-          limit: 20
+          search: hash
         });
 
-    return response.operations.map(group =>
-      mavrykHistoryGroupToHistoryItem(group, {
-        address: accountAddress,
-        assetSlug
-      })
-    );
+    return normalizeBackendHistoryItems(response.operations, accountAddress, [], assetSlug);
   } catch (error) {
     console.error('Error while fetching user operation by hash:', error);
     return [];
@@ -118,29 +127,23 @@ export default async function fetchUserHistory(
     const seenHashes = new Set<string>();
 
     while (collected.length < pseudoLimit && hasMore) {
-      const limit = Math.min(MAX_BACKEND_PAGE_SIZE, pseudoLimit - collected.length);
       const response = tokenAddress
         ? await fetchTokenHistory(tokenAddress, {
             walletAddress: account.publicKeyHash,
-            limit,
             cursor: nextCursor,
             filter: backendFilters
           })
         : await fetchWalletHistory({
             walletAddress: account.publicKeyHash,
-            limit,
             cursor: nextCursor,
             filter: backendFilters
           });
 
-      const normalizedItems = applyLocalTypeFilter(
-        response.operations.map(group =>
-          mavrykHistoryGroupToHistoryItem(group, {
-            address: account.publicKeyHash,
-            assetSlug
-          })
-        ),
-        requestedTypes
+      const normalizedItems = normalizeBackendHistoryItems(
+        response.operations,
+        account.publicKeyHash,
+        requestedTypes,
+        assetSlug
       );
 
       for (const item of normalizedItems) {
@@ -158,9 +161,11 @@ export default async function fetchUserHistory(
       }
     }
 
+    const visibleCollected = collected.slice(0, pseudoLimit);
+
     if (!isFirstPage) {
       return {
-        items: collected,
+        items: visibleCollected,
         cursor: nextCursor,
         hasMore
       };
@@ -169,13 +174,13 @@ export default async function fetchUserHistory(
     const { storageKey, pendingItems, pendingOperations } = await fetchPendingHistoryItems(chainId, account);
     if (!pendingItems.length) {
       return {
-        items: collected,
+        items: visibleCollected,
         cursor: nextCursor,
         hasMore
       };
     }
 
-    const confirmedHashes = new Set(collected.map(item => item.hash));
+    const confirmedHashes = new Set(visibleCollected.map(item => item.hash));
     const filteredPendingOperations = pendingOperations.filter(
       operation => !confirmedHashes.has(operation?.hash ?? '')
     );
@@ -190,7 +195,7 @@ export default async function fetchUserHistory(
     );
 
     return {
-      items: [...filteredPendingItems, ...collected].sort((a, b) => b.addedAt.localeCompare(a.addedAt)),
+      items: [...filteredPendingItems, ...visibleCollected].sort((a, b) => b.addedAt.localeCompare(a.addedAt)),
       cursor: nextCursor,
       hasMore
     };

--- a/src/lib/temple/history/fetch.ts
+++ b/src/lib/temple/history/fetch.ts
@@ -123,10 +123,10 @@ export default async function fetchUserHistory(
   try {
     let nextCursor = cursor;
     let hasMore = true;
-    const collected: UserHistoryItem[] = [];
-    const seenHashes = new Set<string>();
+    let normalizedItems: UserHistoryItem[] = [];
+    const collectedOperations: Awaited<ReturnType<typeof fetchWalletHistory>>['operations'] = [];
 
-    while (collected.length < pseudoLimit && hasMore) {
+    while (hasMore) {
       const response = tokenAddress
         ? await fetchTokenHistory(tokenAddress, {
             walletAddress: account.publicKeyHash,
@@ -139,29 +139,33 @@ export default async function fetchUserHistory(
             filter: backendFilters
           });
 
-      const normalizedItems = normalizeBackendHistoryItems(
-        response.operations,
+      collectedOperations.push(...response.operations);
+
+      normalizedItems = normalizeBackendHistoryItems(
+        collectedOperations,
         account.publicKeyHash,
         requestedTypes,
         assetSlug
       );
-
-      for (const item of normalizedItems) {
-        if (!seenHashes.has(item.hash)) {
-          seenHashes.add(item.hash);
-          collected.push(item);
-        }
-      }
+      const lastVisibleHash = normalizedItems[Math.min(normalizedItems.length, pseudoLimit) - 1]?.hash;
+      const responseLastHash = response.operations[response.operations.length - 1]?.hash;
+      const shouldCompleteTrailingGroup =
+        Boolean(lastVisibleHash) && response.hasMore && responseLastHash === lastVisibleHash;
 
       if (!response.hasMore || response.cursor == null || response.cursor === nextCursor) {
         hasMore = false;
-      } else {
-        nextCursor = response.cursor;
-        hasMore = true;
+        break;
+      }
+
+      nextCursor = response.cursor;
+      hasMore = true;
+
+      if (normalizedItems.length >= pseudoLimit && !shouldCompleteTrailingGroup) {
+        break;
       }
     }
 
-    const visibleCollected = collected.slice(0, pseudoLimit);
+    const visibleCollected = normalizedItems.slice(0, pseudoLimit);
 
     if (!isFirstPage) {
       return {

--- a/src/lib/temple/history/filterParams.ts
+++ b/src/lib/temple/history/filterParams.ts
@@ -172,7 +172,6 @@ const getReturnedTransactionParams = (
   let internalOperationParams = { ...operationParams };
   const hasTarget = Boolean(internalOperationParams.target);
   const hasSender = Boolean(internalOperationParams.sender);
-  console.log(internalOperationParams, 'internalOperationParams');
 
   // params for received transactions
   if (internalOperationParams['target'] === accountAddress) {
@@ -258,15 +257,25 @@ export const getHistoryItemTypesFromParams = (
 export const getBackendHistoryFilters = (
   accountAddress: string,
   operationParams?: GetOperationsTransactionsParams
-): WalletHistoryFilter[] => {
-  if (!operationParams || !Object.keys(operationParams).length) return [];
+): WalletHistoryFilter | undefined => {
+  if (!operationParams || !Object.keys(operationParams).length) return undefined;
 
-  const filters = new Set<WalletHistoryFilter>();
+  if (operationParams.sender === accountAddress) return 'sent';
+  if (operationParams.target === accountAddress) return 'received';
+  if (operationParams.type?.includes('delegation')) return 'delegation';
+  if (operationParams.type?.includes('staking')) return 'staking';
+  if (operationParams.type?.includes('origination')) return 'origination';
+  if (operationParams.type?.includes('reveal')) return 'reveal';
+  if (operationParams.entrypoint === 'swap') return 'interaction';
+  if (operationParams['entrypoint.ne'] === 'transfer' || operationParams['entrypoint.null'] === false) {
+    return 'interaction';
+  }
 
-  if (operationParams.type?.includes('delegation')) filters.add('delegation');
-  if (operationParams.type?.includes('staking')) filters.add('staking');
-  if (operationParams.sender === accountAddress) filters.add('sent');
-  if (operationParams.target === accountAddress) filters.add('received');
+  return undefined;
+};
 
-  return Array.from(filters);
+export const shouldApplyLocalTypeFilter = (operationParams?: GetOperationsTransactionsParams) => {
+  if (!operationParams || !Object.keys(operationParams).length) return false;
+
+  return operationParams.entrypoint === 'swap' || operationParams.type?.includes('other') === true;
 };

--- a/src/lib/temple/history/hook.ts
+++ b/src/lib/temple/history/hook.ts
@@ -95,16 +95,16 @@ export default function useHistory(
     }
 
     const { items: newHistoryItems, cursor: returnedCursor, hasMore } = fetchResult;
+    const newUniqueItems = newHistoryItems.filter(item => !historyItems.some(prevItem => prevItem.hash === item.hash));
+
+    if (newUniqueItems.length === 0) {
+      setCursor(returnedCursor);
+      setLoading(false);
+      setReachedTheEnd(true);
+      return;
+    }
 
     setUserHistory(prev => {
-      const newUniqueItems = newHistoryItems.filter(item => !prev.some(prevItem => prevItem.hash === item.hash));
-
-      if (newUniqueItems.length === 0) {
-        setReachedTheEnd(!hasMore);
-        return prev;
-      }
-
-      // merge + dedupe
       const merged = [...prev, ...newUniqueItems];
       return Array.from(new Map(merged.map(item => [item.hash, item])).values());
     });

--- a/src/lib/temple/history/utils.ts
+++ b/src/lib/temple/history/utils.ts
@@ -13,7 +13,7 @@ import {
 import { fetchFromStorage, putToStorage } from 'lib/storage';
 import { mumavToTz, tzToMumav } from 'lib/temple/helpers';
 import { isTruthy } from 'lib/utils';
-import { MavrykHistoryGroup, MavrykHistoryNetworkFees, MavrykHistoryOperation } from 'mavryk/api/history';
+import { MavrykHistoryNetworkFees, MavrykHistoryOperation, MavrykHistoryOperationDetails } from 'mavryk/api/history';
 
 import { MAV_TOKEN_SLUG, toTokenSlug } from '../../assets';
 import { AssetMetadataBase } from '../../metadata';
@@ -46,7 +46,85 @@ type BackendHistoryNormalizationContext = {
   assetSlug?: string;
 };
 
+type MavrykHistoryOperationsGroup = {
+  hash: string;
+  operations: MavrykHistoryOperation[];
+};
+
+const MVRK_CURRENCY = 'MVRK';
+
 const backendNumberToMumav = (value?: number) => tzToMumav(value ?? 0).toNumber();
+const getBackendOperationTimestamp = (operation: MavrykHistoryOperation) =>
+  operation.details?.timestamp ?? operation.timestamp ?? '';
+
+const getBackendOperationEntrypoint = (operation: MavrykHistoryOperation) =>
+  operation.details?.entrypoint ?? operation.parameter?.entrypoint;
+
+const getBackendOperationId = (operation: MavrykHistoryOperation, fallback = 0) => operation.id ?? fallback;
+const getBackendOperationType = (operation: MavrykHistoryOperation) => operation.details?.type ?? operation.type;
+const isBackendTransactionLikeType = (type: string) => type === 'transaction' || type === 'transfer';
+const isBackendMavCurrency = (currency?: string) => {
+  const normalizedCurrency = currency?.toUpperCase();
+
+  return normalizedCurrency === MVRK_CURRENCY || normalizedCurrency === 'MAV';
+};
+
+const normalizeBackendContractAddress = (contractAddress?: string, currency?: string) => {
+  if (isBackendMavCurrency(currency)) return MAV_TOKEN_SLUG;
+
+  return contractAddress;
+};
+
+const getBackendOperationPriority = (operation: MavrykHistoryOperation) => {
+  if (operation.details) return 0;
+  if (!isBackendTransactionLikeType(getBackendOperationType(operation)) && operation.role !== 'internal') return 1;
+  if (operation.role !== 'internal') return 2;
+
+  return 3;
+};
+
+const sortMavrykHistoryOperations = (a: MavrykHistoryOperation, b: MavrykHistoryOperation) => {
+  const priorityDiff = getBackendOperationPriority(a) - getBackendOperationPriority(b);
+  if (priorityDiff !== 0) return priorityDiff;
+
+  const timestampDiff = getBackendOperationTimestamp(b).localeCompare(getBackendOperationTimestamp(a));
+  if (timestampDiff !== 0) return timestampDiff;
+
+  return getBackendOperationId(b) - getBackendOperationId(a);
+};
+
+export const groupMavrykHistoryOperations = (operations: MavrykHistoryOperation[]): MavrykHistoryOperationsGroup[] => {
+  const groups = Object.values(
+    operations.reduce<StringRecord<MavrykHistoryOperationsGroup>>((acc, operation) => {
+      if (!acc[operation.hash]) {
+        acc[operation.hash] = {
+          hash: operation.hash,
+          operations: []
+        };
+      }
+
+      acc[operation.hash].operations.push(operation);
+
+      return acc;
+    }, {})
+  );
+
+  groups.forEach(group => {
+    group.operations.sort(sortMavrykHistoryOperations);
+  });
+
+  return groups.sort((a, b) => {
+    const firstA = a.operations[0];
+    const firstB = b.operations[0];
+
+    if (!firstA || !firstB) return 0;
+
+    const timestampDiff = getBackendOperationTimestamp(firstB).localeCompare(getBackendOperationTimestamp(firstA));
+    if (timestampDiff !== 0) return timestampDiff;
+
+    return getBackendOperationId(firstB) - getBackendOperationId(firstA);
+  });
+};
 
 const normalizeBackendFees = (fees?: MavrykHistoryNetworkFees) => {
   if (!fees) return undefined;
@@ -68,13 +146,14 @@ const buildBackendOperationBase = (
   index: number
 ): HistoryItemOperationBase => {
   const networkFees = normalizeBackendFees(operation.networkFees);
+  const operationType = getBackendOperationType(operation);
   const reducedOperation: HistoryItemOperationBase = {
-    id: operation.id,
+    id: getBackendOperationId(operation, index),
     level: operation.level ?? 0,
     source,
     amountSigned: getAmountSigned(
       {
-        type: operation.type as TzktOperation['type'],
+        type: operationType as TzktOperation['type'],
         sender: source,
         baker: undefined
       } as TzktOperation,
@@ -83,16 +162,16 @@ const buildBackendOperationBase = (
       source
     ),
     status: stringToHistoryItemStatus(operation.status),
-    addedAt: operation.timestamp,
-    block: '',
+    addedAt: getBackendOperationTimestamp(operation),
+    block: operation.block ?? '',
     hash: operation.hash,
     isHighlighted: false,
     opIndex: index,
     bakerFee: backendNumberToMumav(networkFees?.gasFee),
-    gasUsed: 0,
-    storageUsed: 0,
+    gasUsed: operation.gasUsed ?? 0,
+    storageUsed: operation.storageUsed ?? 0,
     storageFee: backendNumberToMumav(networkFees?.storageFee),
-    entrypoint: operation.parameter?.entrypoint,
+    entrypoint: getBackendOperationEntrypoint(operation),
     networkFees
   };
 
@@ -112,15 +191,16 @@ const getBackendTokenContext = (assetSlug?: string) => {
 };
 
 const buildBackendTokenTransfer = (
-  operation: MavrykHistoryOperation,
+  operation: Pick<MavrykHistoryOperation, 'id' | 'level'>,
   contractAddress: string,
   tokenId: number,
   source: HistoryMember,
-  destination: HistoryMember
+  destination: HistoryMember,
+  amount: number
 ): HistoryItemTokenTransfer => ({
-  totalAmount: String(operation.amount ?? operation.parameter?.amount ?? 0),
-  recipients: [{ to: destination, amount: String(operation.amount ?? operation.parameter?.amount ?? 0) }],
-  id: operation.id,
+  totalAmount: String(amount),
+  recipients: [{ to: destination, amount: String(amount) }],
+  id: operation.id ?? 0,
   level: operation.level ?? 0,
   sender: source,
   tokenContractAddress: contractAddress,
@@ -129,25 +209,128 @@ const buildBackendTokenTransfer = (
   assetSlug: toTokenSlug(contractAddress, tokenId)
 });
 
+const buildBackendFa2TokenTransfer = (
+  operation: MavrykHistoryOperation,
+  contractAddress: string,
+  address: string
+): HistoryItemTokenTransfer | null => {
+  const parameter = operation.parameter;
+  if (!isTzktOperParam_Fa2(parameter)) return null;
+
+  const values = reduceParameterFa2Values(parameter.value, address);
+  const firstValue = values[0];
+  if (!firstValue) return null;
+
+  return {
+    totalAmount: firstValue.totalAmount,
+    recipients: firstValue.recipients,
+    id: operation.id ?? 0,
+    level: operation.level ?? 0,
+    sender: transformToHistoryMember(firstValue.from),
+    tokenContractAddress: contractAddress,
+    tokenId: Number(firstValue.tokenId),
+    tokenType: 'fa2',
+    assetSlug: toTokenSlug(contractAddress, Number(firstValue.tokenId))
+  };
+};
+
+const buildBackendTransferType = (
+  source: HistoryMember,
+  address: string,
+  details?: MavrykHistoryOperationDetails
+): HistoryItemOpTypeEnum => {
+  if (details?.transferType === 'received') return HistoryItemOpTypeEnum.TransferFrom;
+  if (details?.transferType === 'sent') return HistoryItemOpTypeEnum.TransferTo;
+
+  return source.address === address ? HistoryItemOpTypeEnum.TransferTo : HistoryItemOpTypeEnum.TransferFrom;
+};
+
+const buildBackendTransactionOperation = (
+  operation: MavrykHistoryOperation,
+  index: number,
+  context: BackendHistoryNormalizationContext,
+  args: {
+    amount: number;
+    source: HistoryMember;
+    destination: HistoryMember;
+    contractAddress?: string;
+    tokenTransfers?: HistoryItemTokenTransfer;
+    details?: MavrykHistoryOperationDetails;
+  }
+): HistoryItemTransactionOp => {
+  const { address } = context;
+  const { amount, source, destination, contractAddress, tokenTransfers, details } = args;
+  const txBase = buildBackendOperationBase(operation, address, amount, source, index);
+  const entrypoint = getBackendOperationEntrypoint(operation);
+  const isInteraction = Boolean(entrypoint && entrypoint !== 'transfer');
+  const historyTxOp: HistoryItemTransactionOp = {
+    ...txBase,
+    destination,
+    type: isInteraction ? HistoryItemOpTypeEnum.Interaction : buildBackendTransferType(source, address, details),
+    assetSlug: MAV_TOKEN_SLUG
+  };
+
+  if (entrypoint) historyTxOp.entrypoint = entrypoint;
+
+  if (tokenTransfers) {
+    historyTxOp.tokenTransfers = tokenTransfers;
+    historyTxOp.contractAddress = tokenTransfers.tokenContractAddress;
+    historyTxOp.assetSlug = tokenTransfers.assetSlug;
+  } else if (contractAddress && contractAddress !== MAV_TOKEN_SLUG) {
+    historyTxOp.contractAddress = contractAddress;
+    historyTxOp.assetSlug = toTokenSlug(contractAddress, 0);
+  } else {
+    historyTxOp.contractAddress = MAV_TOKEN_SLUG;
+    historyTxOp.assetSlug = MAV_TOKEN_SLUG;
+  }
+
+  return historyTxOp;
+};
+
 const deriveBackendItemType = (
-  group: MavrykHistoryGroup,
+  group: MavrykHistoryOperationsGroup,
   items: IndividualHistoryItem[],
   address: string
 ): HistoryItemOpTypeEnum => {
-  if (group.transferType === 'sent') return HistoryItemOpTypeEnum.TransferTo;
-  if (group.transferType === 'received') return HistoryItemOpTypeEnum.TransferFrom;
-  if (group.type === 'delegation') return HistoryItemOpTypeEnum.Delegation;
-  if (group.type === 'staking') return HistoryItemOpTypeEnum.Staking;
+  const firstOperation = group.operations[0];
+  const firstItem = items[0];
+
+  if (!firstOperation) return HistoryItemOpTypeEnum.Other;
+  const firstOperationType = getBackendOperationType(firstOperation);
+  if (firstOperationType === 'other') return HistoryItemOpTypeEnum.Other;
+  if (firstOperationType === 'delegation') return HistoryItemOpTypeEnum.Delegation;
+  if (firstOperationType === 'staking') return HistoryItemOpTypeEnum.Staking;
+  if (firstOperationType === 'origination') return HistoryItemOpTypeEnum.Origination;
+  if (firstOperationType === 'reveal') return HistoryItemOpTypeEnum.Reveal;
 
   if (items.some(item => item.entrypoint?.toLowerCase() === 'swap')) return HistoryItemOpTypeEnum.Swap;
-  if (items.length > 1 && items.some(item => item.type === HistoryItemOpTypeEnum.Interaction)) {
+  if (items.length > 1 && !firstOperation.details?.transferType) return HistoryItemOpTypeEnum.Multiple;
+  if (items.some(item => item.entrypoint === 'placeSellOrder' || item.entrypoint === 'placeBuyOrder')) {
     return HistoryItemOpTypeEnum.Multiple;
   }
 
-  const firstItem = items[0];
+  if (firstOperation.details?.transferType === 'sent') return HistoryItemOpTypeEnum.TransferTo;
+  if (firstOperation.details?.transferType === 'received') return HistoryItemOpTypeEnum.TransferFrom;
   if (!firstItem) return HistoryItemOpTypeEnum.Other;
 
-  if (firstItem.type === HistoryItemOpTypeEnum.Interaction) return HistoryItemOpTypeEnum.Interaction;
+  if (
+    firstItem.source.address === address &&
+    firstItem.type === HistoryItemOpTypeEnum.TransferTo &&
+    items.length === 1
+  ) {
+    return HistoryItemOpTypeEnum.TransferTo;
+  }
+
+  if (firstItem.entrypoint !== undefined && firstItem.entrypoint !== 'transfer') {
+    return HistoryItemOpTypeEnum.Interaction;
+  }
+
+  if ('tokenTransfers' in firstItem && firstItem.tokenTransfers && items.length === 1) {
+    return firstItem.tokenTransfers.recipients?.find(recipient => recipient.to.address === address)
+      ? HistoryItemOpTypeEnum.TransferFrom
+      : HistoryItemOpTypeEnum.TransferTo;
+  }
+
   if (firstItem.type === HistoryItemOpTypeEnum.TransferTo && firstItem.source.address !== address) {
     return HistoryItemOpTypeEnum.TransferFrom;
   }
@@ -162,69 +345,175 @@ const reduceOneBackendOperation = (
 ): IndividualHistoryItem | null => {
   const { address, assetSlug } = context;
   const tokenContext = getBackendTokenContext(assetSlug);
-  const sourceAddress = operation.parameter?.from ?? operation.sender ?? '';
-  const destinationAddress = operation.parameter?.to ?? operation.target ?? '';
+  const details = operation.details ?? undefined;
+  const effectiveOperationType = getBackendOperationType(operation);
+  const sourceAddress = details?.from ?? operation.parameter?.from ?? operation.sender ?? '';
+  const destinationAddress = details?.to ?? operation.parameter?.to ?? operation.target ?? '';
   const source = transformToHistoryMember(sourceAddress);
   const destination = transformToHistoryMember(destinationAddress);
-  const amount = operation.amount ?? operation.parameter?.amount ?? 0;
+  const amount = details?.amount ?? operation.amount ?? operation.parameter?.amount ?? 0;
+  const detailsContractAddress = normalizeBackendContractAddress(details?.tokenAddress, details?.currency);
 
-  switch (operation.type) {
+  switch (effectiveOperationType) {
     case 'delegation': {
       const delegationOpBase = buildBackendOperationBase(operation, address, 0, source, index);
+
       return {
         ...delegationOpBase,
         type: HistoryItemOpTypeEnum.Delegation,
-        newDelegate: destinationAddress ? destination : null
+        prevDelegate:
+          operation.prevDelegate || details?.prevDelegate
+            ? transformToHistoryMember(operation.prevDelegate ?? details?.prevDelegate ?? '')
+            : null,
+        newDelegate:
+          operation.newDelegate || details?.newDelegate
+            ? transformToHistoryMember(operation.newDelegate ?? details?.newDelegate ?? '')
+            : destinationAddress
+            ? destination
+            : null
       };
     }
     case 'staking': {
       const stakingOpBase = buildBackendOperationBase(operation, address, amount, source, index);
+
       return {
         ...stakingOpBase,
         amount,
-        action: (operation.parameter?.entrypoint ?? 'stake') as StakingActions,
+        action: (details?.action ?? operation.action ?? operation.parameter?.entrypoint ?? 'stake') as StakingActions,
         sender: source,
-        baker: destinationAddress ? destination : null,
+        baker:
+          operation.baker || details?.baker
+            ? transformToHistoryMember(operation.baker ?? details?.baker ?? '')
+            : destinationAddress
+            ? destination
+            : null,
         type: HistoryItemOpTypeEnum.Staking
       };
     }
-    case 'transaction':
-    default: {
-      const txBase = buildBackendOperationBase(operation, address, amount, source, index);
-      const entrypoint = operation.parameter?.entrypoint;
-      const isInteraction = Boolean(entrypoint && entrypoint !== 'transfer');
-      const historyTxOp: HistoryItemTransactionOp = {
-        ...txBase,
-        destination,
-        assetSlug: tokenContext ? toTokenSlug(tokenContext.contractAddress, tokenContext.tokenId) : MAV_TOKEN_SLUG,
-        type: isInteraction ? HistoryItemOpTypeEnum.Interaction : HistoryItemOpTypeEnum.TransferTo
-      };
+    case 'origination': {
+      const contractBalance = String(details?.contractBalance ?? operation.contractBalance ?? 0);
+      const originationOpBase = buildBackendOperationBase(operation, address, Number(contractBalance), source, index);
+      const originatedContract = operation.originatedContract ?? details?.originatedContract;
 
-      if (tokenContext) {
-        historyTxOp.contractAddress = tokenContext.contractAddress;
-        historyTxOp.tokenTransfers = buildBackendTokenTransfer(
-          operation,
-          tokenContext.contractAddress,
-          tokenContext.tokenId,
+      return {
+        ...originationOpBase,
+        originatedContract: originatedContract ? transformToHistoryMember(originatedContract) : undefined,
+        contractBalance,
+        type: HistoryItemOpTypeEnum.Origination
+      };
+    }
+    case 'reveal': {
+      const revealOpBase = buildBackendOperationBase(operation, address, 0, source, index);
+
+      return {
+        ...revealOpBase,
+        type: HistoryItemOpTypeEnum.Reveal
+      };
+    }
+    case 'transaction':
+    case 'transfer': {
+      if (details) {
+        const tokenId = details.tokenId ?? tokenContext?.tokenId ?? 0;
+        const tokenTransfers =
+          detailsContractAddress && detailsContractAddress !== MAV_TOKEN_SLUG
+            ? buildBackendTokenTransfer(operation, detailsContractAddress, tokenId, source, destination, amount)
+            : undefined;
+
+        return buildBackendTransactionOperation(operation, index, context, {
+          amount,
           source,
-          destination
-        );
-      } else {
-        historyTxOp.contractAddress = MAV_TOKEN_SLUG;
+          destination,
+          contractAddress: detailsContractAddress ?? MAV_TOKEN_SLUG,
+          tokenTransfers,
+          details
+        });
       }
 
-      if (entrypoint) historyTxOp.entrypoint = entrypoint;
+      const parameter = operation.parameter;
 
-      return historyTxOp;
+      if (isTzktOperParam_Fa2(parameter)) {
+        const contractAddress = normalizeBackendContractAddress(operation.target ?? tokenContext?.contractAddress);
+        if (!contractAddress) return null;
+
+        const tokenTransfers =
+          contractAddress === MAV_TOKEN_SLUG ? null : buildBackendFa2TokenTransfer(operation, contractAddress, address);
+        const txSource = tokenTransfers?.sender ?? source;
+        const txDestination = tokenTransfers?.recipients?.[0]?.to ?? destination;
+        const txAmount = Number(tokenTransfers?.totalAmount ?? amount);
+
+        return buildBackendTransactionOperation(operation, index, context, {
+          amount: txAmount,
+          source: txSource,
+          destination: txDestination,
+          contractAddress,
+          tokenTransfers: tokenTransfers ?? undefined
+        });
+      }
+
+      if (isTzktOperParam_Fa12(parameter)) {
+        if (parameter.entrypoint === 'approve') return null;
+
+        const contractAddress = normalizeBackendContractAddress(operation.target ?? tokenContext?.contractAddress);
+        if (!contractAddress) return null;
+
+        const txSource = transformToHistoryMember(parameter.value.from);
+        const txDestination = transformToHistoryMember(parameter.value.to);
+        const txAmount = Number(parameter.value.value);
+        const tokenTransfers =
+          contractAddress === MAV_TOKEN_SLUG
+            ? undefined
+            : buildBackendTokenTransfer(operation, contractAddress, 0, txSource, txDestination, txAmount);
+
+        return buildBackendTransactionOperation(operation, index, context, {
+          amount: txAmount,
+          source: txSource,
+          destination: txDestination,
+          contractAddress,
+          tokenTransfers
+        });
+      }
+
+      const contractAddress = normalizeBackendContractAddress(
+        tokenContext?.contractAddress ?? (effectiveOperationType === 'transfer' ? operation.target : undefined)
+      );
+      const tokenTransfers =
+        contractAddress && contractAddress !== MAV_TOKEN_SLUG
+          ? buildBackendTokenTransfer(
+              operation,
+              contractAddress,
+              tokenContext?.tokenId ?? 0,
+              source,
+              destination,
+              amount
+            )
+          : undefined;
+
+      return buildBackendTransactionOperation(operation, index, context, {
+        amount,
+        source,
+        destination,
+        contractAddress: contractAddress ?? MAV_TOKEN_SLUG,
+        tokenTransfers
+      });
+    }
+    default: {
+      const otherOpBase = buildBackendOperationBase(operation, address, 0, source, index);
+
+      return {
+        ...otherOpBase,
+        destination: destination.address ? destination : undefined,
+        type: HistoryItemOpTypeEnum.Other,
+        name: effectiveOperationType
+      };
     }
   }
 };
 
 export function mavrykHistoryGroupToHistoryItem(
-  group: MavrykHistoryGroup,
+  group: MavrykHistoryOperationsGroup,
   context: BackendHistoryNormalizationContext
 ): UserHistoryItem {
-  const operations = [...group.operations].sort((a, b) => b.id - a.id);
+  const operations = [...group.operations].sort(sortMavrykHistoryOperations);
   const historyItemOperations = operations
     .map((operation, index) => reduceOneBackendOperation(operation, index, context))
     .filter(isTruthy);
@@ -237,7 +526,7 @@ export function mavrykHistoryGroupToHistoryItem(
   return {
     type,
     hash: group.hash,
-    addedAt: group.timestamp,
+    addedAt: firstOperation?.addedAt ?? getBackendOperationTimestamp(operations[0]),
     status,
     operations: historyItemOperations,
     highlightedOperationIndex: 0,

--- a/src/lib/temple/history/utils.ts
+++ b/src/lib/temple/history/utils.ts
@@ -49,6 +49,7 @@ type BackendHistoryNormalizationContext = {
 type MavrykHistoryOperationsGroup = {
   hash: string;
   operations: MavrykHistoryOperation[];
+  summaryOperation?: MavrykHistoryOperation;
 };
 
 const MVRK_CURRENCY = 'MVRK';
@@ -62,7 +63,6 @@ const getBackendOperationEntrypoint = (operation: MavrykHistoryOperation) =>
 
 const getBackendOperationId = (operation: MavrykHistoryOperation, fallback = 0) => operation.id ?? fallback;
 const getBackendOperationType = (operation: MavrykHistoryOperation) => operation.details?.type ?? operation.type;
-const isBackendTransactionLikeType = (type: string) => type === 'transaction' || type === 'transfer';
 const isBackendMavCurrency = (currency?: string) => {
   const normalizedCurrency = currency?.toUpperCase();
 
@@ -75,55 +75,69 @@ const normalizeBackendContractAddress = (contractAddress?: string, currency?: st
   return contractAddress;
 };
 
-const getBackendOperationPriority = (operation: MavrykHistoryOperation) => {
-  if (operation.details) return 0;
-  if (!isBackendTransactionLikeType(getBackendOperationType(operation)) && operation.role !== 'internal') return 1;
-  if (operation.role !== 'internal') return 2;
+const getBackendOperationKey = (operation: MavrykHistoryOperation) =>
+  [
+    operation.hash,
+    getBackendOperationId(operation, -1),
+    operation.type,
+    operation.role ?? '',
+    operation.counter ?? '',
+    getBackendOperationTimestamp(operation),
+    operation.sender ?? '',
+    operation.target ?? ''
+  ].join(':');
 
-  return 3;
-};
+const getNestedBackendOperations = (operation: MavrykHistoryOperation): MavrykHistoryOperation[] => {
+  if (!operation.operations?.length) {
+    return [operation];
+  }
 
-const sortMavrykHistoryOperations = (a: MavrykHistoryOperation, b: MavrykHistoryOperation) => {
-  const priorityDiff = getBackendOperationPriority(a) - getBackendOperationPriority(b);
-  if (priorityDiff !== 0) return priorityDiff;
-
-  const timestampDiff = getBackendOperationTimestamp(b).localeCompare(getBackendOperationTimestamp(a));
-  if (timestampDiff !== 0) return timestampDiff;
-
-  return getBackendOperationId(b) - getBackendOperationId(a);
+  return operation.operations.flatMap(childOperation => getNestedBackendOperations(childOperation));
 };
 
 export const groupMavrykHistoryOperations = (operations: MavrykHistoryOperation[]): MavrykHistoryOperationsGroup[] => {
-  const groups = Object.values(
-    operations.reduce<StringRecord<MavrykHistoryOperationsGroup>>((acc, operation) => {
-      if (!acc[operation.hash]) {
-        acc[operation.hash] = {
-          hash: operation.hash,
-          operations: []
-        };
+  const groupedOperations = new Map<string, MavrykHistoryOperationsGroup>();
+  const groupOrder: string[] = [];
+  const operationKeys = new Map<string, Set<string>>();
+
+  operations.forEach(operation => {
+    if (!groupedOperations.has(operation.hash)) {
+      groupedOperations.set(operation.hash, {
+        hash: operation.hash,
+        operations: [],
+        summaryOperation: operation.operations?.length ? operation : undefined
+      });
+      operationKeys.set(operation.hash, new Set());
+      groupOrder.push(operation.hash);
+    }
+
+    const group = groupedOperations.get(operation.hash);
+    const groupOperationKeys = operationKeys.get(operation.hash);
+    const normalizedOperations = getNestedBackendOperations(operation);
+
+    if (!group || !groupOperationKeys) {
+      return;
+    }
+
+    if (operation.operations?.length && !group.summaryOperation) {
+      group.summaryOperation = operation;
+    }
+
+    normalizedOperations.forEach(normalizedOperation => {
+      const operationKey = getBackendOperationKey(normalizedOperation);
+
+      if (groupOperationKeys.has(operationKey)) {
+        return;
       }
 
-      acc[operation.hash].operations.push(operation);
-
-      return acc;
-    }, {})
-  );
-
-  groups.forEach(group => {
-    group.operations.sort(sortMavrykHistoryOperations);
+      groupOperationKeys.add(operationKey);
+      group.operations.push(normalizedOperation);
+    });
   });
 
-  return groups.sort((a, b) => {
-    const firstA = a.operations[0];
-    const firstB = b.operations[0];
-
-    if (!firstA || !firstB) return 0;
-
-    const timestampDiff = getBackendOperationTimestamp(firstB).localeCompare(getBackendOperationTimestamp(firstA));
-    if (timestampDiff !== 0) return timestampDiff;
-
-    return getBackendOperationId(firstB) - getBackendOperationId(firstA);
-  });
+  return groupOrder
+    .map(hash => groupedOperations.get(hash))
+    .filter((group): group is MavrykHistoryOperationsGroup => Boolean(group));
 };
 
 const normalizeBackendFees = (fees?: MavrykHistoryNetworkFees) => {
@@ -292,7 +306,7 @@ const deriveBackendItemType = (
   items: IndividualHistoryItem[],
   address: string
 ): HistoryItemOpTypeEnum => {
-  const firstOperation = group.operations[0];
+  const firstOperation = group.summaryOperation ?? group.operations[0];
   const firstItem = items[0];
 
   if (!firstOperation) return HistoryItemOpTypeEnum.Other;
@@ -304,14 +318,18 @@ const deriveBackendItemType = (
   if (firstOperationType === 'reveal') return HistoryItemOpTypeEnum.Reveal;
 
   if (items.some(item => item.entrypoint?.toLowerCase() === 'swap')) return HistoryItemOpTypeEnum.Swap;
-  if (items.length > 1 && !firstOperation.details?.transferType) return HistoryItemOpTypeEnum.Multiple;
   if (items.some(item => item.entrypoint === 'placeSellOrder' || item.entrypoint === 'placeBuyOrder')) {
     return HistoryItemOpTypeEnum.Multiple;
   }
 
-  if (firstOperation.details?.transferType === 'sent') return HistoryItemOpTypeEnum.TransferTo;
-  if (firstOperation.details?.transferType === 'received') return HistoryItemOpTypeEnum.TransferFrom;
   if (!firstItem) return HistoryItemOpTypeEnum.Other;
+
+  if (firstOperation.details?.transferType === 'sent' && items.length === 1) {
+    return HistoryItemOpTypeEnum.TransferTo;
+  }
+  if (firstOperation.details?.transferType === 'received' && items.length === 1) {
+    return HistoryItemOpTypeEnum.TransferFrom;
+  }
 
   if (
     firstItem.source.address === address &&
@@ -321,7 +339,7 @@ const deriveBackendItemType = (
     return HistoryItemOpTypeEnum.TransferTo;
   }
 
-  if (firstItem.entrypoint !== undefined && firstItem.entrypoint !== 'transfer') {
+  if (items.some(item => item.entrypoint !== undefined && item.entrypoint !== 'transfer')) {
     return HistoryItemOpTypeEnum.Interaction;
   }
 
@@ -331,11 +349,19 @@ const deriveBackendItemType = (
       : HistoryItemOpTypeEnum.TransferTo;
   }
 
-  if (firstItem.type === HistoryItemOpTypeEnum.TransferTo && firstItem.source.address !== address) {
+  if (
+    firstItem.type === HistoryItemOpTypeEnum.TransferTo &&
+    firstItem.source.address !== address &&
+    items.length === 1
+  ) {
     return HistoryItemOpTypeEnum.TransferFrom;
   }
 
-  return firstItem.type ?? HistoryItemOpTypeEnum.Other;
+  if (firstItem.type && items.length === 1) {
+    return firstItem.type;
+  }
+
+  return HistoryItemOpTypeEnum.Interaction;
 };
 
 const reduceOneBackendOperation = (
@@ -348,7 +374,7 @@ const reduceOneBackendOperation = (
   const details = operation.details ?? undefined;
   const effectiveOperationType = getBackendOperationType(operation);
   const sourceAddress = details?.from ?? operation.parameter?.from ?? operation.sender ?? '';
-  const destinationAddress = details?.to ?? operation.parameter?.to ?? operation.target ?? '';
+  const destinationAddress = details?.to ?? details?.contract ?? operation.parameter?.to ?? operation.target ?? '';
   const source = transformToHistoryMember(sourceAddress);
   const destination = transformToHistoryMember(destinationAddress);
   const amount = details?.amount ?? operation.amount ?? operation.parameter?.amount ?? 0;
@@ -410,6 +436,7 @@ const reduceOneBackendOperation = (
         type: HistoryItemOpTypeEnum.Reveal
       };
     }
+    case 'interaction':
     case 'transaction':
     case 'transfer': {
       if (details) {
@@ -513,12 +540,17 @@ export function mavrykHistoryGroupToHistoryItem(
   group: MavrykHistoryOperationsGroup,
   context: BackendHistoryNormalizationContext
 ): UserHistoryItem {
-  const operations = [...group.operations].sort(sortMavrykHistoryOperations);
+  const operations = [...group.operations];
+  const primaryOperation = group.summaryOperation ?? operations[0];
   const historyItemOperations = operations
     .map((operation, index) => reduceOneBackendOperation(operation, index, context))
     .filter(isTruthy);
 
-  const status = deriveHistoryItemStatus(historyItemOperations.length ? historyItemOperations : [{ status: 'failed' }]);
+  const status = deriveHistoryItemStatus(
+    historyItemOperations.length
+      ? historyItemOperations
+      : [{ status: primaryOperation ? stringToHistoryItemStatus(primaryOperation.status) : 'failed' }]
+  );
   const type = deriveBackendItemType(group, historyItemOperations, context.address);
   const firstOperation = historyItemOperations[0];
   const oldestOperation = historyItemOperations[historyItemOperations.length - 1];
@@ -526,7 +558,7 @@ export function mavrykHistoryGroupToHistoryItem(
   return {
     type,
     hash: group.hash,
-    addedAt: firstOperation?.addedAt ?? getBackendOperationTimestamp(operations[0]),
+    addedAt: firstOperation?.addedAt ?? (primaryOperation ? getBackendOperationTimestamp(primaryOperation) : ''),
     status,
     operations: historyItemOperations,
     highlightedOperationIndex: 0,

--- a/src/lib/temple/history/utils.ts
+++ b/src/lib/temple/history/utils.ts
@@ -18,7 +18,6 @@ import { MavrykHistoryNetworkFees, MavrykHistoryOperation, MavrykHistoryOperatio
 import { MAV_TOKEN_SLUG, toTokenSlug } from '../../assets';
 import { AssetMetadataBase } from '../../metadata';
 
-import { safetyMultiplier } from './consts';
 import { getMoneyDiff, isZero } from './helpers';
 import {
   Fa2TransferSummaryArray,
@@ -1075,7 +1074,70 @@ type BuildPendingOperationObjecttype = {
   baker?: string | null;
   kind?: string;
   estimation?: Estimate;
+  assetSlug?: string;
+  feeMumav?: number;
 };
+
+const normalizePendingAmount = (amount?: number | string) => {
+  if (amount == null) return undefined;
+
+  const amountBN = new BigNumber(amount);
+  if (amountBN.isNaN()) return undefined;
+
+  return amountBN.toNumber();
+};
+
+const getPendingAssetContext = (assetSlug?: string) => {
+  if (!assetSlug || assetSlug === MAV_TOKEN_SLUG) {
+    return {
+      currency: MVRK_CURRENCY
+    };
+  }
+
+  const [tokenAddress, tokenIdRaw] = assetSlug.split('_');
+
+  return {
+    tokenAddress,
+    tokenId: Number(tokenIdRaw ?? '0')
+  };
+};
+
+const normalizePendingStakingAction = (kind?: string) => {
+  switch (kind) {
+    case StakingActions.unstake:
+      return StakingActions.unstake;
+
+    case StakingActions.restake:
+      return StakingActions.restake;
+
+    case 'finalize_unstake':
+    case StakingActions.finalize:
+      return StakingActions.finalize;
+
+    case StakingActions.slash_staked:
+      return StakingActions.slash_staked;
+
+    case StakingActions.slash_unstaked:
+      return StakingActions.slash_unstaked;
+
+    case StakingActions.stake:
+    default:
+      return StakingActions.stake;
+  }
+};
+
+const buildPendingNetworkFees = (estimation?: Estimate, feeMumav?: number): MavrykHistoryNetworkFees => {
+  const gasFeeMumav = feeMumav ?? estimation?.suggestedFeeMumav ?? 0;
+  const storageFeeMumav = estimation?.burnFeeMumav ?? 0;
+
+  return {
+    totalFee: mumavToTz(gasFeeMumav + storageFeeMumav).toNumber(),
+    gasFee: mumavToTz(gasFeeMumav).toNumber(),
+    storageFee: mumavToTz(storageFeeMumav).toNumber(),
+    burnedFromFees: mumavToTz(storageFeeMumav).toNumber()
+  };
+};
+
 export async function buildPendingOperationObject({
   operation,
   type,
@@ -1086,78 +1148,126 @@ export async function buildPendingOperationObject({
   prevDelegate,
   estimation,
   kind,
-  baker
+  baker,
+  assetSlug,
+  feeMumav
 }: BuildPendingOperationObjecttype) {
   if (!operation) return null;
 
-  const now = dayjs().toISOString();
+  const hash = operation.opHash || operation.hash;
+  if (!hash) return null;
 
-  const baseOperationFoelds = {
+  const now = dayjs().toISOString();
+  const normalizedAmount = normalizePendingAmount(amount);
+  const networkFees = buildPendingNetworkFees(estimation, feeMumav);
+
+  const baseOperationFields: MavrykHistoryOperation = {
     type,
     id: Date.now(),
-    level: null,
     timestamp: now,
-    allocationFee: estimation?.suggestedFeeMumav ?? 0,
-    block: null,
-    hash: operation.opHash || operation.hash,
-    counter: null,
-    sender: { address: sender },
-    source: { address: sender },
-    destination: to ? { address: to } : undefined,
+    hash,
+    sender,
     gasLimit: estimation?.gasLimit ?? 0,
     gasUsed: estimation?.consumedMilligas ? Math.ceil(Number(estimation.consumedMilligas) / 1000) : 0,
     storageLimit: estimation?.storageLimit ?? 0,
-    amount: amount ?? 0,
     storageUsed: estimation?.storageLimit ?? 0,
-    bakerFee: Math.ceil((estimation?.suggestedFeeMumav ?? 0) * safetyMultiplier),
-    storageFee: Math.ceil((estimation?.burnFeeMumav ?? 0) * safetyMultiplier),
-    networkFees: {
-      totalFee: mumavToTz((estimation?.suggestedFeeMumav ?? 0) + (estimation?.burnFeeMumav ?? 0)).toNumber(),
-      gasFee: mumavToTz(estimation?.suggestedFeeMumav ?? 0).toNumber(),
-      storageFee: mumavToTz(estimation?.burnFeeMumav ?? 0).toNumber(),
-      burnedFromFees: mumavToTz(estimation?.burnFeeMumav ?? 0).toNumber()
-    },
-    status: 'pending',
-    isPending: true
+    networkFees,
+    status: 'pending'
   };
 
+  if (normalizedAmount !== undefined) {
+    baseOperationFields.amount = normalizedAmount;
+  }
+
+  if (to) {
+    baseOperationFields.target = to;
+  }
+
   switch (type) {
-    case 'delegation':
+    case 'delegation': {
+      const delegationTarget = newDelegate ?? to;
+
       return {
-        ...baseOperationFoelds,
-        newDelegate: {
-          address: newDelegate
-        },
-        prevDelegate: {
-          address: prevDelegate
-        },
-        bakerFee: estimation?.suggestedFeeMumav ?? null
-      };
-    case 'staking':
-      return {
-        ...baseOperationFoelds,
-        kind,
-        baker: {
-          address: baker
+        ...baseOperationFields,
+        target: delegationTarget ?? undefined,
+        newDelegate: newDelegate ?? null,
+        prevDelegate: prevDelegate ?? null,
+        details: {
+          type: 'delegation',
+          from: sender,
+          to: delegationTarget ?? undefined,
+          newDelegate: newDelegate ?? null,
+          prevDelegate: prevDelegate ?? null
         }
       };
-    case 'transaction':
+    }
+
+    case 'staking': {
+      const action = normalizePendingStakingAction(kind);
+      const stakingTarget = baker ?? to;
+
       return {
-        ...baseOperationFoelds,
-        target: {
-          address: to
+        ...baseOperationFields,
+        target: stakingTarget ?? undefined,
+        action,
+        baker: baker ?? undefined,
+        details: {
+          type: 'staking',
+          action,
+          amount: normalizedAmount,
+          from: sender,
+          to: stakingTarget ?? undefined,
+          baker: baker ?? undefined
         }
       };
+    }
+
+    case 'transaction': {
+      const { tokenAddress, tokenId, currency } = getPendingAssetContext(assetSlug);
+
+      return {
+        ...baseOperationFields,
+        details: {
+          type: 'transfer',
+          transferType: 'sent',
+          from: sender,
+          to,
+          amount: normalizedAmount,
+          currency,
+          tokenAddress,
+          tokenId,
+          entrypoint: tokenAddress ? 'transfer' : undefined
+        }
+      };
+    }
+
     case 'origination':
+      return {
+        ...baseOperationFields,
+        details: {
+          type: 'origination',
+          from: sender,
+          to
+        }
+      };
+
     case 'reveal':
+      return {
+        ...baseOperationFields,
+        details: {
+          type: 'reveal',
+          from: sender
+        }
+      };
+
     default:
       return {
-        ...baseOperationFoelds
+        ...baseOperationFields
       };
   }
 }
 
-export type CustomPendingOperation = Awaited<ReturnType<typeof buildPendingOperationObject>>;
+export type CustomPendingOperation = MavrykHistoryOperation;
 
 export const putOperationIntoStorage = async (
   chainId: string | null | undefined,

--- a/src/mavryk/api/history.ts
+++ b/src/mavryk/api/history.ts
@@ -10,9 +10,32 @@ const HistoryNetworkFeesSchema = z.object({
   totalFee: NumberLikeSchema,
   usdAmount: NumberLikeSchema.optional(),
   gasFee: NumberLikeSchema,
+  bakerFee: NumberLikeSchema.optional(),
   storageFee: NumberLikeSchema,
   burnedFromFees: NumberLikeSchema
 });
+
+const HistoryOperationDetailsSchema = z
+  .object({
+    type: z.string().optional(),
+    transferType: z.string().optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    tokenAddress: z.string().optional(),
+    tokenId: NumberLikeSchema.optional(),
+    timestamp: z.string().optional(),
+    amount: NumberLikeSchema.optional(),
+    currency: z.string().optional(),
+    usdAmount: NumberLikeSchema.optional(),
+    entrypoint: z.string().optional(),
+    action: z.string().optional(),
+    baker: z.string().optional(),
+    prevDelegate: z.string().nullable().optional(),
+    newDelegate: z.string().nullable().optional(),
+    originatedContract: z.string().optional(),
+    contractBalance: NumberLikeSchema.optional()
+  })
+  .passthrough();
 
 const HistoryParameterSchema = z
   .object({
@@ -21,53 +44,55 @@ const HistoryParameterSchema = z
     currency: z.string().optional(),
     usdAmount: NumberLikeSchema.optional(),
     from: z.string().optional(),
-    to: z.string().optional()
+    to: z.string().optional(),
+    value: z.unknown().optional()
   })
   .passthrough();
 
 const HistoryOperationSchema = z.object({
-  id: NumberLikeSchema,
+  id: NumberLikeSchema.optional(),
   hash: z.string(),
   type: z.string(),
+  role: z.string().optional(),
+  block: z.string().optional(),
   level: NumberLikeSchema.optional(),
-  timestamp: z.string(),
+  counter: NumberLikeSchema.optional(),
+  timestamp: z.string().optional(),
   sender: z.string().optional(),
   target: z.string().optional(),
   amount: NumberLikeSchema.optional(),
   parameter: HistoryParameterSchema.nullish(),
+  details: HistoryOperationDetailsSchema.nullish(),
+  gasLimit: NumberLikeSchema.optional(),
+  gasUsed: NumberLikeSchema.optional(),
+  storageLimit: NumberLikeSchema.optional(),
+  storageUsed: NumberLikeSchema.optional(),
+  action: z.string().optional(),
+  baker: z.string().optional(),
+  prevDelegate: z.string().nullable().optional(),
+  newDelegate: z.string().nullable().optional(),
+  originatedContract: z.string().optional(),
+  contractBalance: NumberLikeSchema.optional(),
   networkFees: HistoryNetworkFeesSchema.optional(),
   status: z.string()
 });
 
-const HistoryGroupSchema = z.object({
-  type: z.string(),
-  hash: z.string(),
-  timestamp: z.string(),
-  amount: NumberLikeSchema.optional(),
-  parameter: HistoryParameterSchema.nullish(),
-  networkFees: HistoryNetworkFeesSchema.optional(),
-  transferType: z.string().optional(),
-  status: z.string(),
-  operations: z.array(HistoryOperationSchema)
-});
-
 const HistoryResponseSchema = z.object({
   walletAddress: z.string(),
-  operations: z.array(HistoryGroupSchema),
+  operations: z.array(HistoryOperationSchema),
   cursor: NumberLikeSchema.nullish(),
   hasMore: z.boolean()
 });
 
 export type WalletHistoryFilter = 'sent' | 'received' | 'delegation' | 'staking';
 export type MavrykHistoryNetworkFees = z.infer<typeof HistoryNetworkFeesSchema>;
+export type MavrykHistoryOperationDetails = z.infer<typeof HistoryOperationDetailsSchema>;
 export type MavrykHistoryParameter = z.infer<typeof HistoryParameterSchema>;
 export type MavrykHistoryOperation = z.infer<typeof HistoryOperationSchema>;
-export type MavrykHistoryGroup = z.infer<typeof HistoryGroupSchema>;
 export type MavrykHistoryResponse = z.infer<typeof HistoryResponseSchema>;
 
 export type FetchHistoryRequest = {
   walletAddress?: string;
-  limit?: number;
   cursor?: number;
   search?: string;
   filter?: WalletHistoryFilter[];
@@ -81,7 +106,6 @@ async function getWalletAddressOrThrow(walletAddress?: string) {
 
 function buildHistoryParams(params: FetchHistoryRequest) {
   return {
-    limit: params.limit,
     cursor: params.cursor,
     search: params.search,
     filter: params.filter?.length ? params.filter.join(',') : undefined

--- a/src/mavryk/api/history.ts
+++ b/src/mavryk/api/history.ts
@@ -86,7 +86,14 @@ const HistoryResponseSchema = z.object({
   hasMore: z.boolean()
 });
 
-export type WalletHistoryFilter = 'sent' | 'received' | 'delegation' | 'staking';
+export type WalletHistoryFilter =
+  | 'sent'
+  | 'received'
+  | 'delegation'
+  | 'staking'
+  | 'origination'
+  | 'reveal'
+  | 'interaction';
 export type MavrykHistoryNetworkFees = z.infer<typeof HistoryNetworkFeesSchema>;
 export type MavrykHistoryOperationDetails = z.infer<typeof HistoryOperationDetailsSchema>;
 export type MavrykHistoryParameter = z.infer<typeof HistoryParameterSchema>;
@@ -101,7 +108,7 @@ export type FetchHistoryRequest = {
   walletAddress?: string;
   cursor?: number;
   search?: string;
-  filter?: WalletHistoryFilter[];
+  filter?: WalletHistoryFilter;
 };
 
 async function getWalletAddressOrThrow(walletAddress?: string) {
@@ -114,7 +121,7 @@ function buildHistoryParams(params: FetchHistoryRequest) {
   return {
     cursor: params.cursor,
     search: params.search,
-    filter: params.filter?.length ? params.filter.join(',') : undefined
+    filter: params.filter
   };
 }
 

--- a/src/mavryk/api/history.ts
+++ b/src/mavryk/api/history.ts
@@ -21,6 +21,7 @@ const HistoryOperationDetailsSchema = z
     transferType: z.string().optional(),
     from: z.string().optional(),
     to: z.string().optional(),
+    contract: z.string().optional(),
     tokenAddress: z.string().optional(),
     tokenId: NumberLikeSchema.optional(),
     timestamp: z.string().optional(),
@@ -73,6 +74,7 @@ const HistoryOperationSchema = z.object({
   newDelegate: z.string().nullable().optional(),
   originatedContract: z.string().optional(),
   contractBalance: NumberLikeSchema.optional(),
+  operations: z.array(z.unknown()).optional(),
   networkFees: HistoryNetworkFeesSchema.optional(),
   status: z.string()
 });
@@ -88,8 +90,12 @@ export type WalletHistoryFilter = 'sent' | 'received' | 'delegation' | 'staking'
 export type MavrykHistoryNetworkFees = z.infer<typeof HistoryNetworkFeesSchema>;
 export type MavrykHistoryOperationDetails = z.infer<typeof HistoryOperationDetailsSchema>;
 export type MavrykHistoryParameter = z.infer<typeof HistoryParameterSchema>;
-export type MavrykHistoryOperation = z.infer<typeof HistoryOperationSchema>;
-export type MavrykHistoryResponse = z.infer<typeof HistoryResponseSchema>;
+export type MavrykHistoryOperation = Omit<z.infer<typeof HistoryOperationSchema>, 'operations'> & {
+  operations?: MavrykHistoryOperation[];
+};
+export type MavrykHistoryResponse = Omit<z.infer<typeof HistoryResponseSchema>, 'operations'> & {
+  operations: MavrykHistoryOperation[];
+};
 
 export type FetchHistoryRequest = {
   walletAddress?: string;
@@ -118,7 +124,7 @@ async function fetchHistory(path: string, params: FetchHistoryRequest = {}) {
       params: buildHistoryParams(params)
     });
 
-    return HistoryResponseSchema.parse(data);
+    return HistoryResponseSchema.parse(data) as MavrykHistoryResponse;
   } catch (error) {
     throw new Error(extractMavrykApiErrorMessage(error));
   }


### PR DESCRIPTION
# Title
MAV-3764: Add account flow, scoped Mavryk auth/contacts, and history improvements

## Summary
This PR introduces a dedicated add/import account flow and extends the Mavryk backend integration with scoped auth, encrypted contacts sync, and backend-driven history. It also fixes several multi-account issues, improves history rendering across the wallet, and normalizes pending send, delegation, and staking operations so they match the backend history model and display correctly while pending.

## Added
- New `Add or Import Account` screen with separate actions for creating, importing, and restoring accounts.
- Updated manage-account entry points and new account action icons.
- Mavryk API modules for auth, contacts, history, storage, tokens, and RWAs.
- Dynamic Mavryk API URL resolution by network.
- Encrypted contacts sync with remote fetch/save support, local cache handling, and contact type mapping (`user`, `validator`, `contract`).
- Contacts state migrations for the new backend-backed contacts structure.
- Backend-driven wallet/token history pagination and operation search by hash.
- Auth/signature documentation with diagrams in `docs/api/auth.md`.

## Fixed / Improved
- Multi-wallet auth flow, including wallet/network-scoped token storage.
- Correct auth-wallet resolution for HD subaccounts and non-signing accounts.
- Multi-account contacts sync/caching issues across wallet and network scopes.
- Contact updates now preserve contact types on `PUT`.
- Truncated contact names now show tooltips in relevant UI surfaces.
- History pagination “reached the end” issue.
- Interaction history item mapping and history details popup address/fee handling.
- Pending operations handling for send, delegate, stake, and related flows.
- Pending operations are now stored in backend history format with asset-aware amounts, staking/delegation details, and explicit network fee data.
- Pending history fetching now supports both legacy stored operations and the new backend-shaped records, and watch-only accounts no longer show the staking CTA in the tokens tab.
- Add/import account UI styling and account management UX polish.
- Money diff rendering issues.
- RWA reducer/loading updates.
- Deploy workflow validation to confirm `manifest.json` is present at the root of the packaged zip.

## Other
- Extension version bumped to `2.0.0`.

## Documentation Update
- Added `docs/api/auth.md` and supporting diagrams covering auth/signing flow and backend data handling.
